### PR TITLE
Splitting Contracts

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -21,19 +21,17 @@ open class RecordENoteContract: P8eContract() {
     @Function(invokedBy = Specifications.PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
-        validateRequirements {
+        validateRequirements(
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
-            requireThat(
-                eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
-                eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
-                eNote.eNote.id.isValid()                     orError "ENote missing ID",
-                eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
-                eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
-                eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
-                eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
-                eNote.signedDate.isValid()                   orError "ENote missing signed date",
-                eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
-            )
-        }
+            eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
+            eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
+            eNote.eNote.id.isValid()                     orError "ENote missing ID",
+            eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
+            eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
+            eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
+            eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
+            eNote.signedDate.isValid()                   orError "ENote missing signed date",
+            eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
+        )
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -1,0 +1,39 @@
+package io.provenance.scope.loan.contracts
+
+import io.dartinc.registry.v1beta1.ENote
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.isValid
+import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.requireThat
+import io.provenance.scope.loan.utility.validateRequirements
+
+@Participants(roles = [Specifications.PartyType.OWNER])
+@ScopeSpecification(["tech.figure.loan"])
+open class RecordENoteContract: P8eContract() {
+
+    @Function(invokedBy = Specifications.PartyType.OWNER)
+    @Record(LoanScopeFacts.eNote)
+    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
+        validateRequirements {
+            // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
+            requireThat(
+                eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
+                eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
+                eNote.eNote.id.isValid()                     orError "ENote missing ID",
+                eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
+                eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
+                eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
+                eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
+                eNote.signedDate.isValid()                   orError "ENote missing signed date",
+                eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
+            )
+        }
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -22,8 +22,8 @@ import tech.figure.validation.v1beta1.ValidationResults
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanContract(
-    @Record(LoanScopeFacts.asset) val existingAsset: Asset,
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
+    @Record(LoanScopeFacts.asset) val existingAsset: Asset? = null,
+    @Record(LoanScopeFacts.eNote) val existingENote: ENote? = null,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
@@ -72,10 +72,10 @@ open class RecordLoanContract(
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
-    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also { // TODO: Confirm if we want existing and/or input to be nullable and adjust code below accordingly
+    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote? = null) = eNote?.also {
         validateRequirements {
             if (existingENote != null) {
-                //requireThat(existingENote.checksum == eNote.checksum orError "cannot modify or remove eNote during loan onboarding"), // use specific contract instead
+                requireThat((existingENote.eNote.checksum == it.eNote.checksum) orError "ENote with a different checksum already exists on chain for the specified scope; ENote modifications are not allowed!")
             }
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
             requireThat(


### PR DESCRIPTION
- Creating a RecordENoteContract for onboarding of enotes without loan documenets
- Updating RecordLoanContract to a) optionally include on chain loan / enote b) optionally allow onboarding of enote 

note: servicing data does not exist yet ([pending daves changing](https://github.com/provenance-io/metadata-asset-model/pull/9)). Once merged, this should be added to the recordEnoteContract according to dave. 