### PR TITLE
Add Kotest, draft tests for utilities & validation result submission

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -19,7 +19,7 @@ object Versions {
     object Dependencies {
         const val Grpc = "1.39.0"
         const val ProtocGenValidate = "0.6.7"
-        const val Protobuf = "3.20.+"
+        const val Protobuf = "3.20.1"
         const val SemVer = "1.1.2"
         object Provenance {
             const val Scope = "0.4.9"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -8,6 +8,7 @@ import org.gradle.plugin.use.PluginDependenciesSpec
 object Versions {
     const val Kotlin = "1.6.21"
     const val GitHubRelease = "2.2.12"
+    const val Kotest = "5.2.3"
     const val KrotoPlus = "0.6.1"
     object Plugins {
         const val NexusPublishing = "1.1.0"
@@ -39,6 +40,7 @@ object Plugins {
 }
 
 object Dependencies {
+    // Build
     val GitHubRelease = DependencySpec(
         name = "com.github.breadmoirai:github-release",
         version = Versions.GitHubRelease,
@@ -47,6 +49,23 @@ object Dependencies {
         name = "net.swiftzer.semver:semver",
         version = Versions.Dependencies.SemVer,
     )
+    // Testing
+    object Kotest {
+        val Framework = DependencySpec(
+            name = "io.kotest:kotest-runner-junit5",
+            version = Versions.Kotest,
+        )
+        val Assertions = DependencySpec(
+            name = "io.kotest:kotest-assertions-core",
+            version = Versions.Kotest,
+        )
+        val Property = DependencySpec(
+            name = "io.kotest:kotest-property",
+            version = Versions.Kotest,
+        )
+    }
+
+    // Dependencies
     object Grpc {
         val Stub = DependencySpec(
             name = "io.grpc:grpc-stub",

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -18,4 +18,14 @@ dependencies {
         Dependencies.Provenance.ScopeUtil,
         Dependencies.Provenance.MetadataAssetModel,
     )
+
+    testImplementationSpecs(
+        Dependencies.Kotest.Framework,
+        Dependencies.Kotest.Assertions,
+        Dependencies.Kotest.Property,
+    )
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -9,7 +9,7 @@ import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.LoanDocuments
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStates
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.ValidationResults
+import tech.figure.validation.v1beta1.Validation
 
 object LoanScopeFacts {
 
@@ -33,7 +33,7 @@ data class LoanPackage(
     // Optional
     @Record(LoanScopeFacts.documents) var documents: LoanDocuments? = null, // list of document metadata with URIs that point to documents in EOS
     @Record(LoanScopeFacts.loanStates) var loanStates: LoanStates? = null, // list of loan states
-    @Record(LoanScopeFacts.validationResults) var validationResults: ValidationResults? = null, // object containing list of third party validation results and a summary of exceptions
+    @Record(LoanScopeFacts.validationResults) var validationRecord: Validation? = null, // object containing list of third party validation results and a summary of exceptions
 
     // Loans registered with DART would include:
     @Record(LoanScopeFacts.eNote) var eNote: ENote? = null

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -10,7 +10,6 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.requireThat
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStates
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -21,19 +21,17 @@ open class RecordENoteContract: P8eContract() {
     @Function(invokedBy = Specifications.PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
-        validateRequirements {
+        validateRequirements(
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
-            requireThat(
-                eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
-                eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
-                eNote.eNote.id.isValid()                     orError "ENote missing ID",
-                eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
-                eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
-                eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
-                eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
-                eNote.signedDate.isValid()                   orError "ENote missing signed date",
-                eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
-            )
-        }
+            eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
+            eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
+            eNote.eNote.id.isValid()                     orError "ENote missing ID",
+            eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
+            eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
+            eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
+            eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
+            eNote.signedDate.isValid()                   orError "ENote missing signed date",
+            eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
+        )
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -1,0 +1,39 @@
+package io.provenance.scope.loan.contracts
+
+import io.dartinc.registry.v1beta1.ENote
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.isValid
+import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.requireThat
+import io.provenance.scope.loan.utility.validateRequirements
+
+@Participants(roles = [Specifications.PartyType.OWNER])
+@ScopeSpecification(["tech.figure.loan"])
+open class RecordENoteContract: P8eContract() {
+
+    @Function(invokedBy = Specifications.PartyType.OWNER)
+    @Record(LoanScopeFacts.eNote)
+    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
+        validateRequirements {
+            // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
+            requireThat(
+                eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
+                eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
+                eNote.eNote.id.isValid()                     orError "ENote missing ID",
+                eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
+                eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
+                eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
+                eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
+                eNote.signedDate.isValid()                   orError "ENote missing signed date",
+                eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
+            )
+        }
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -11,7 +11,6 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.requireThat
 import io.provenance.scope.loan.utility.validateRequirements
 
 @Participants(roles = [Specifications.PartyType.OWNER])

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -11,7 +11,6 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.requireThat
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.LoanDocuments

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -21,8 +21,8 @@ import tech.figure.validation.v1beta1.ValidationResults
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanContract(
-    @Record(LoanScopeFacts.asset) val existingAsset: Asset,
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
+    @Record(LoanScopeFacts.asset) val existingAsset: Asset? = null,
+    @Record(LoanScopeFacts.eNote) val existingENote: ENote? = null,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
@@ -71,10 +71,10 @@ open class RecordLoanContract(
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
-    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also { // TODO: Confirm if we want existing and/or input to be nullable and adjust code below accordingly
+    open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote? = null) = eNote?.also {
         validateRequirements {
             if (existingENote != null) {
-                //requireThat(existingENote.checksum == eNote.checksum orError "cannot modify or remove eNote during loan onboarding"), // use specific contract instead
+                requireThat((existingENote.eNote.checksum == it.eNote.checksum) orError "ENote with a different checksum already exists on chain for the specified scope; ENote modifications are not allowed!")
             }
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
             requireThat(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -20,7 +20,7 @@ open class RecordLoanValidationResultsContract(
     @Record(LoanScopeFacts.validationResults) val validationRecord: Validation,
 ) : P8eContract() {
 
-    @Function(invokedBy = PartyType.CUSTODIAN) // TODO: Change to VALIDATOR?
+    @Function(invokedBy = PartyType.OWNER) // TODO: Change to VALIDATOR?
     @Record(LoanScopeFacts.validationResults)
     open fun recordLoanValidationResults(
         @Input(name = "resultSubmission") submission: ValidationResultSubmission
@@ -52,9 +52,12 @@ open class RecordLoanValidationResultsContract(
             iteration.request.requestId == submission.requestId
         }.let { index ->
             validationRecord.toBuilder().also { recordBuilder ->
-                recordBuilder.iterationList[index] = validationRecord.iterationList[index].toBuilder().apply {
-                    results = submission.results
-                }.build()
+                recordBuilder.setIteration(
+                    index,
+                    validationRecord.iterationList[index].toBuilder().apply {
+                        results = submission.results
+                    }.build()
+                )
             }.build()
         }
     }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -10,38 +10,52 @@ import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.proto.ValidationResultSubmission
 import io.provenance.scope.loan.utility.isValid
-import tech.figure.validation.v1beta1.ValidationIteration
-import tech.figure.validation.v1beta1.ValidationResults
+import tech.figure.validation.v1beta1.Validation
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationResultsContract(
-    @Record(LoanScopeFacts.validationResults) val validationIteration: ValidationIteration,
+    @Record(LoanScopeFacts.validationResults) val validationRecord: Validation,
 ) : P8eContract() {
 
-    @Function(invokedBy = PartyType.OWNER) // TODO: Change to VALIDATOR?
+    @Function(invokedBy = PartyType.CUSTODIAN) // TODO: Change to VALIDATOR?
     @Record(LoanScopeFacts.validationResults)
-    open fun recordLoanValidationResults(@Input(name = "newResults") newResults: ValidationResults): ValidationResults {
-        validateRequirements(
-            newResults.resultSetUuid.isValid()          orError "Result set UUID is missing",
-            newResults.resultSetEffectiveTime.isValid() orError "Result set date is missing",
-            (newResults.validationExceptionCount >= 0)  orError "Invalid validation exception count",
-            (newResults.validationWarningCount >= 0)    orError "Invalid validation warning count",
-            (newResults.validationItemsCount > 0)       orError "No validation items were provided",
-            newResults.resultSetProvider.isNotBlank()   orError "Result set provider is missing",
-            (newResults.resultSetProvider == validationIteration.request.requesterName)
-                    orError "Result set provider does not match what was requested in this validation iteration",
-        )
-        // TODO: Update just the relevant ValidationIteration and change method signature & annotations accordingly
-        /*val newResultsBuilder = ValidationResults.newBuilder().mergeFrom(existingResults)
-        newResultsBuilder.addValidationResultSet(newResults.validationResultSet)
-        if (!existingResults.hasField(latestResultSetDate) || newResults.resultSetDate > existingResults.latestResultSetDate) {
-            newResultsBuilder.setLatestResultSetDate(newResults.resultSetDate)
-            if (newResults.hasField(ratingAgencyGrading)) newResultsBuilder.setLatestGrading(newResults.ratingAgencyGrading)
-            // TODO: how to merge exception/warning counts? override vs. merge unique
+    open fun recordLoanValidationResults(
+        @Input(name = "resultSubmission") submission: ValidationResultSubmission
+    ): Validation {
+        validateRequirements {
+            requireThat(
+                submission.results.resultSetUuid.isValid()          orError "Result set UUID is missing",
+                submission.requestId.isValid()                      orError "Request ID is missing",
+                submission.results.resultSetEffectiveTime.isValid() orError "Result set date is missing",
+                (submission.results.validationExceptionCount >= 0)  orError "Invalid validation exception count",
+                (submission.results.validationWarningCount >= 0)    orError "Invalid validation warning count",
+                (submission.results.validationItemsCount > 0)       orError "No validation items were provided",
+                submission.results.resultSetProvider.isNotBlank()   orError "Result set provider is missing",
+            )
+            validationRecord.iterationList.singleOrNull { iteration ->
+                iteration.request.requestId == submission.requestId
+            }.let { maybeIteration ->
+                requireThat(
+                    if (maybeIteration === null) {
+                        false orError "No single validation iteration with a matching request ID exists"
+                    } else {
+                        (submission.results.resultSetProvider == maybeIteration.request.requesterName) orError
+                            "Result set provider does not match what was requested in this validation iteration"
+                    }
+                )
+            }
         }
-        return newResultsBuilder.build()*/
-        return newResults // TODO: Temporary stopgap
+        return validationRecord.iterationList.indexOfLast { iteration -> // The enforcement above ensures exactly one match
+            iteration.request.requestId == submission.requestId
+        }.let { index ->
+            validationRecord.toBuilder().also { recordBuilder ->
+                recordBuilder.iterationList[index] = validationRecord.iterationList[index].toBuilder().apply {
+                    results = submission.results
+                }.build()
+            }.build()
+        }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataExtensions.kt
@@ -1,22 +1,32 @@
 package io.provenance.scope.loan.utility
 
-import com.google.protobuf.Message
-import com.google.protobuf.Timestamp
-import io.provenance.scope.util.toInstant
-import tech.figure.util.v1beta1.Checksum
-import tech.figure.util.v1beta1.Date
-import tech.figure.util.v1beta1.Money
-import tech.figure.util.v1beta1.UUID
-import java.time.Instant
+import com.google.protobuf.Message as ProtobufMessage
+import com.google.protobuf.Timestamp as ProtobufTimestamp
+import java.util.UUID as JavaUUID
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+import tech.figure.util.v1beta1.Date as FigureTechDate
+import tech.figure.util.v1beta1.Money as FigureTechMoney
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
-internal fun Message?.isSet() = this !== null && this != this.defaultInstanceForType
+@Suppress("TooGenericExceptionCaught")
+private fun tryOrFalse(fn: () -> Any): Boolean =
+    try {
+        fn()
+        true
+    } catch (e: Exception) {
+        false
+    }
 
-internal fun Timestamp?.isValid() = isSet() && this!!.toInstant() < Instant.now()
+internal fun ProtobufMessage?.isSet() = this !== null && this != this.defaultInstanceForType
 
-internal fun Date?.isValid() = isSet() && this!!.value.isNotBlank()
+internal fun ProtobufTimestamp?.isValid() = isSet()
 
-internal fun Checksum?.isValid() = isSet() && this!!.checksum.isNotBlank()
+internal fun FigureTechDate?.isValid() = isSet() && this!!.value.isNotBlank()
 
-internal fun UUID?.isValid() = isSet() && this!!.value.isNotBlank()
+internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank()
 
-internal fun Money?.isValid() = isSet() && this!!.amount > 0
+internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse {
+    JavaUUID.fromString(this.value)
+}
+
+internal fun FigureTechMoney?.isValid() = isSet()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -1,0 +1,41 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.string.shouldContain
+import io.provenance.scope.loan.proto.ValidationResultSubmission
+import io.provenance.scope.loan.test.Constructors.contractWithEmptyExistingValidationRecord
+import io.provenance.scope.loan.test.Constructors.contractWithSingleValidationIteration
+import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import io.provenance.scope.loan.test.Constructors.validResultSubmission
+import io.provenance.scope.loan.utility.ContractViolationException
+
+class RecordLoanValidationResultsUnitTest : WordSpec({
+    "recordLoanValidationResults" When {
+        "given an invalid input" should {
+            "throw an appropriate exception" {
+                ValidationResultSubmission.getDefaultInstance().let { emptyResultSubmission ->
+                    shouldThrow<ContractViolationException> {
+                        contractWithEmptyExistingValidationRecord.apply {
+                            recordLoanValidationResults(emptyResultSubmission)
+                        }
+                    }.let { exception ->
+                        exception.message shouldContain "Result set UUID is missing"
+                    }
+                }
+            }
+        }
+        "given a valid input" xshould { // TODO: Enable once validResultSubmission is implemented
+            "not throw an exception" {
+                shouldNotThrow<ContractViolationException> {
+                    randomProtoUuid.let { iterationRequestId ->
+                        contractWithSingleValidationIteration(iterationRequestId).apply {
+                            recordLoanValidationResults(validResultSubmission(iterationRequestId))
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -1,0 +1,40 @@
+package io.provenance.scope.loan.test
+
+import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
+import io.provenance.scope.loan.proto.ValidationResultSubmission
+import io.provenance.scope.util.toProtoTimestamp
+import tech.figure.validation.v1beta1.Validation
+import tech.figure.validation.v1beta1.ValidationIteration
+import tech.figure.validation.v1beta1.ValidationRequest
+import java.time.OffsetDateTime
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
+
+object Constructors {
+    val randomProtoUuid: FigureTechUUID
+        get() = FigureTechUUID.newBuilder().apply {
+            value = java.util.UUID.randomUUID().toString()
+        }.build()
+
+    val contractWithEmptyExistingValidationRecord: RecordLoanValidationResultsContract
+        get() = RecordLoanValidationResultsContract(
+            Validation.getDefaultInstance()
+        )
+    fun contractWithSingleValidationIteration(requestID: FigureTechUUID) = RecordLoanValidationResultsContract(
+        Validation.newBuilder().also { validationRecordBuilder ->
+            validationRecordBuilder.clearIteration()
+            validationRecordBuilder.addIteration(
+                ValidationIteration.newBuilder().also { iterationBuilder ->
+                    iterationBuilder.request = ValidationRequest.newBuilder().also { requestBuilder ->
+                        requestBuilder.requestId = requestID
+                        requestBuilder.ruleSetId = randomProtoUuid
+                        requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
+                    }.build()
+                }.build()
+            )
+        }.build()
+    )
+    fun validResultSubmission(iterationRequestID: FigureTechUUID) = ValidationResultSubmission.newBuilder().apply {
+        requestId = iterationRequestID
+        // TODO: Set remaining fields
+    }.build()
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -1,0 +1,77 @@
+package io.provenance.scope.loan.test
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bind
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.uuid
+import io.provenance.scope.loan.utility.ContractEnforcement
+import io.provenance.scope.loan.utility.ContractViolation
+import io.provenance.scope.loan.utility.ContractViolationException
+import io.provenance.scope.loan.utility.ContractViolationMap
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
+
+/**
+ * Generators of [Arb]itrary instances of loan scope classes.
+ */
+internal object LoanPackageArbs {
+    /* Metadata asset model */
+    val figureTechUuidArb: Arb<FigureTechUUID> = Arb.bind(
+        listOf(
+            Arb.uuid()
+        )
+    ) { javaUuid4 ->
+        FigureTechUUID.newBuilder().apply {
+            value = javaUuid4.toString()
+        }.build()
+    }
+    /* Contract requirements */
+    val contractViolation: Arb<ContractViolation> = Arb.string()
+    val contractEnforcement: Arb<ContractEnforcement> = Arb.bind(
+        Arb.boolean(),
+        Arb.string(),
+    ) { requirement, violationReport ->
+        ContractEnforcement(requirement, violationReport)
+    }
+    val contractViolationMapArb: Arb<ContractViolationMap> = Arb.bind(
+        Arb.list(contractViolation),
+        Arb.list(Arb.uInt()),
+    ) { violationList, countList ->
+        violationList.zip(countList).toMap().toMutableMap()
+    }
+}
+
+/**
+ * Defines a custom [Matcher] to check the violation count value in a [ContractViolationException].
+ */
+internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolationException> { exception ->
+    { count: UInt ->
+        if (count == 1U) {
+            "$count violation"
+        } else {
+            "$count violations"
+        }
+    }.let { violationPrinter: (UInt) -> String ->
+        return@Matcher MatcherResult(
+            exception.overallViolationCount == violationCount,
+            {
+                "Exception had ${violationPrinter(exception.overallViolationCount)} " +
+                    "but we expected ${violationPrinter(violationCount)}"
+            },
+            { "Exception should not have ${violationPrinter(violationCount)}" },
+        )
+    }
+}
+
+/**
+ * Wraps the custom matcher [throwViolationCount] following the style outlined in the
+ * [Kotest documentation](https://kotest.io/docs/assertions/custom-matchers.html#extension-variants).
+ */
+internal infix fun ContractViolationException.shouldHaveViolationCount(violationCount: UInt) = apply {
+    this should throwViolationCount(violationCount)
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -9,27 +9,15 @@ import io.kotest.property.arbitrary.boolean
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.uInt
-import io.kotest.property.arbitrary.uuid
 import io.provenance.scope.loan.utility.ContractEnforcement
 import io.provenance.scope.loan.utility.ContractViolation
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.ContractViolationMap
-import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 /**
- * Generators of [Arb]itrary instances of loan scope classes.
+ * Generators of [Arb]itrary instances.
  */
 internal object LoanPackageArbs {
-    /* Metadata asset model */
-    val figureTechUuidArb: Arb<FigureTechUUID> = Arb.bind(
-        listOf(
-            Arb.uuid()
-        )
-    ) { javaUuid4 ->
-        FigureTechUUID.newBuilder().apply {
-            value = javaUuid4.toString()
-        }.build()
-    }
     /* Contract requirements */
     val contractViolation: Arb<ContractViolation> = Arb.string()
     val contractEnforcement: Arb<ContractEnforcement> = Arb.bind(

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
@@ -1,0 +1,95 @@
+package io.provenance.scope.loan.utility
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.ints.shouldBeInRange
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.test.LoanPackageArbs
+
+class ContractRequirementsTest : WordSpec({
+    /* Helpers */
+    fun getExpectedViolationCount(enforcements: List<ContractEnforcement>) =
+        enforcements.fold(
+            emptyMap<ContractViolation, UInt>() to 0U
+        ) { (violationMap, overallCount), (rule, violationReport) ->
+            if (!rule) {
+                violationMap.getOrDefault(violationReport, 0U).let { currentIndividualCount ->
+                    if (currentIndividualCount == 0U) {
+                        violationMap.plus(violationReport to 1U) to overallCount + 1U
+                    } else {
+                        violationMap.plus(violationReport to currentIndividualCount + 1U) to overallCount
+                    }
+                }
+            } else {
+                violationMap to overallCount
+            }
+        }.second
+    /* Tests */
+    "validateRequirements" When {
+        "accepting a list of enforcements" should {
+            "accept infix syntax" {
+                checkAll<Boolean, ContractViolation> { rule, violationReport ->
+                    (rule orError violationReport).shouldBeTypeOf<ContractEnforcement>()
+                    (rule orError violationReport) shouldBe ContractEnforcement(rule, violationReport)
+                }
+            }
+            "return violations only for failed conditions" {
+                checkAll(Arb.list(LoanPackageArbs.contractEnforcement)) { enforcementList ->
+                    val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
+                    if (expectedOverallViolationCount > 0U) {
+                        shouldThrow<ContractViolationException> {
+                            validateRequirements(*enforcementList.toTypedArray())
+                        }.let { exception ->
+                            exception shouldHaveViolationCount expectedOverallViolationCount
+                        }
+                    } else {
+                        shouldNotThrow<ContractViolationException> {
+                            validateRequirements(*enforcementList.toTypedArray())
+                        }
+                    }
+                }
+            }
+        }
+        "invoked with a function body" should {
+            "return violations only for failed conditions" {
+                checkAll(
+                    Arb.list(LoanPackageArbs.contractEnforcement),
+                    Arb.list(LoanPackageArbs.contractEnforcement),
+                ) { enforcementListA, enforcementListB ->
+                    val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
+                    if (expectedOverallViolationCount > 0U) {
+                        shouldThrow<ContractViolationException> {
+                            validateRequirements {
+                                5 shouldBeGreaterThanOrEqual 4
+                                requireThat(*enforcementListB.toTypedArray())
+                                3 shouldBeLessThan 4
+                                requireThat(*enforcementListA.toTypedArray())
+                                2 shouldBeInRange 0..9
+                            }
+                        }.let { exception ->
+                            exception shouldHaveViolationCount expectedOverallViolationCount
+                        }
+                    } else {
+                        shouldNotThrow<ContractViolationException> {
+                            validateRequirements {
+                                2 shouldBeInRange 0..9
+                                requireThat(*enforcementListB.toTypedArray())
+                                5 shouldBeGreaterThanOrEqual 4
+                                requireThat(*enforcementListA.toTypedArray())
+                                3 shouldBeLessThan 4
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
@@ -1,11 +1,27 @@
 package io.provenance.scope.loan.utility
 
 import com.google.protobuf.Any
+import com.google.protobuf.Timestamp
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.double
+import io.kotest.property.arbitrary.localDate
+import io.kotest.property.arbitrary.localDateTime
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.uuid
+import io.kotest.property.checkAll
+import io.kotest.property.forAll
 import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import io.provenance.scope.util.toProtoTimestamp
 import tech.figure.validation.v1beta1.ValidationIteration
 import tech.figure.validation.v1beta1.ValidationRequest
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+import tech.figure.util.v1beta1.Date as FigureTechDate
+import tech.figure.util.v1beta1.Money as FigureTechMoney
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 class DataExtensionsTest : WordSpec({
     "Message.isSet" should {
@@ -23,6 +39,86 @@ class DataExtensionsTest : WordSpec({
             }
             "return false for specific fields in an altered object" {
                 modifiedValidationRequest.effectiveTime.isSet() shouldBe false
+            }
+        }
+    }
+    "Timestamp.isValid" should {
+        "return false for a default instance" {
+            Timestamp.getDefaultInstance().isValid() shouldBe false
+        }
+        "return true for any UTC date other than the epoch" {
+            forAll(Arb.localDateTime(minLocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 1))) { randomLocalDateTime ->
+                randomLocalDateTime.atOffset(ZoneOffset.UTC).toProtoTimestamp().isValid()
+            }
+        }
+    }
+    "Date.isValid" should {
+        "return false for a default instance" {
+            FigureTechDate.getDefaultInstance().isValid() shouldBe false
+        }
+        "return true for any valid date" {
+            forAll(Arb.localDate()) { randomLocalDate ->
+                FigureTechDate.newBuilder().apply {
+                    value = randomLocalDate.toString()
+                }.build().isValid()
+            }
+        }
+    }
+    "Checksum.isValid" should {
+        "return false for a default instance" {
+            FigureTechChecksum.getDefaultInstance().isValid() shouldBe false
+        }
+        "return false for an invalid instance" {
+            FigureTechChecksum.newBuilder().apply {
+                checksum = ""
+            }.build().isValid() shouldBe false
+        }
+        "return true for any non-empty string" {
+            forAll(Arb.string(minSize = 1)) { randomString ->
+                FigureTechChecksum.newBuilder().apply {
+                    checksum = randomString
+                }.build().isValid()
+            }
+        }
+    }
+    "FigureTechUUID.isValid" should {
+        "return false for a default instance" {
+            FigureTechUUID.getDefaultInstance().isValid() shouldBe false
+        }
+        "return false for an invalid instance" {
+            checkAll(Arb.string(minSize = 1, maxSize = 35)) { randomShortString ->
+                FigureTechUUID.newBuilder().apply {
+                    value = randomShortString
+                }.build().isValid() shouldBe false
+            }
+            checkAll(Arb.string(minSize = 37)) { randomLongString ->
+                FigureTechUUID.newBuilder().apply {
+                    value = randomLongString
+                }.build().isValid() shouldBe false
+            }
+        }
+        "return true for any valid instance" {
+            forAll(Arb.uuid()) { randomJavaUuidV4 ->
+                FigureTechUUID.newBuilder().apply {
+                    value = randomJavaUuidV4.toString()
+                }.build().isValid()
+            }
+        }
+    }
+    "Money.isValid" should {
+        "return false for a default instance" {
+            FigureTechMoney.getDefaultInstance().isValid() shouldBe false
+        }
+        "return true for any number other than zero" {
+            forAll(Arb.double(max = -0.1)) { randomDouble ->
+                FigureTechMoney.newBuilder().apply {
+                    amount = randomDouble
+                }.build().isValid()
+            }
+            forAll(Arb.double(min = 0.1)) { randomDouble ->
+                FigureTechMoney.newBuilder().apply {
+                    amount = randomDouble
+                }.build().isValid()
             }
         }
     }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
@@ -1,0 +1,29 @@
+package io.provenance.scope.loan.utility
+
+import com.google.protobuf.Any
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import tech.figure.validation.v1beta1.ValidationIteration
+import tech.figure.validation.v1beta1.ValidationRequest
+
+class DataExtensionsTest : WordSpec({
+    "Message.isSet" should {
+        "return false for any default instance" {
+            ValidationIteration.getDefaultInstance().isSet() shouldBe false
+            ValidationIteration.newBuilder().build().isSet() shouldBe false
+            Any.getDefaultInstance().isSet() shouldBe false
+            Any.newBuilder().build().isSet() shouldBe false
+        }
+        ValidationRequest.newBuilder().apply {
+            requestId = randomProtoUuid
+        }.build().let { modifiedValidationRequest ->
+            "return true for any altered object" {
+                modifiedValidationRequest.isSet() shouldBe true
+            }
+            "return false for specific fields in an altered object" {
+                modifiedValidationRequest.effectiveTime.isSet() shouldBe false
+            }
+        }
+    }
+})


### PR DESCRIPTION
### Changes
- Add Kotest to `contract` project
- Define some basic helpers for test classes
- Add basic tests for contract requirement code
- Add basic tests for data utility functions
- Draft logic for validation result submission contract
- Draft initial test cases for validation result submission contract
- Correct and slightly refactor contract requirement code
- Correct and clarify data validation extensions
### Notes
- 2nd rebase was unintentional, please "Squash and merge" to keep the Git history clean