### PR TITLE
Updating Record names to v0.1.7 of the metadata-asset-model

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -23,7 +23,7 @@ object Versions {
         const val SemVer = "1.1.2"
         object Provenance {
             const val Scope = "0.4.9"
-            const val MetadataAssetModel = "0.1.6"
+            const val MetadataAssetModel = "0.1.7"
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -7,37 +7,26 @@ import io.provenance.scope.contract.proto.Specifications
 import io.provenance.scope.contract.spec.P8eScopeSpecification
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.LoanDocuments
-import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStates
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.Validation
+import tech.figure.validation.v1beta1.LoanValidation
 
 object LoanScopeFacts {
-
     const val asset = "asset"
     const val documents = "documents"
-    const val loanStates = "loan_states"
-    const val servicingRights = "servicing_rights"
-    const val validationResults = "validation_results"
-
-    // Loans registered with DART would include:
-    const val eNote = "e_note"
-
+    const val servicingRights = "servicingRights"
+    const val servicingData = "servicingData"
+    const val loanValidations = "loanValidations"
+    const val eNote = "eNote"
 }
 
 data class LoanPackage(
-
-    // Required
     @Record(LoanScopeFacts.asset) var asset: Asset,
     @Record(LoanScopeFacts.servicingRights) var servicingRights: ServicingRights, // Defaults to the lender
-
-    // Optional
     @Record(LoanScopeFacts.documents) var documents: LoanDocuments? = null, // list of document metadata with URIs that point to documents in EOS
-    @Record(LoanScopeFacts.loanStates) var loanStates: LoanStates? = null, // list of loan states
-    @Record(LoanScopeFacts.validationResults) var validationRecord: Validation? = null, // object containing list of third party validation results and a summary of exceptions
-
-    // Loans registered with DART would include:
+    @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData? = null, // list of loan state metadata
+    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation? = null, // object containing list of third party validation results and a summary of exceptions
     @Record(LoanScopeFacts.eNote) var eNote: ENote? = null
-
 )
 
 @ScopeSpecificationDefinition(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -11,32 +11,32 @@ import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
-import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStates
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class AppendLoanStatesContract(
-    @Record(LoanScopeFacts.loanStates) val existingLoanStates: LoanStates,
+    @Record(LoanScopeFacts.servicingData) val existingServicingData: ServicingData,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
-    @Record(LoanScopeFacts.loanStates)
-    open fun appendLoanStates(@Input(LoanScopeFacts.loanStates) newLoanStates: LoanStates): LoanStates {
-        val newLoanStateList = LoanStates.newBuilder().mergeFrom(existingLoanStates)
+    @Record(LoanScopeFacts.servicingData)
+    open fun appendLoanStates(@Input(LoanScopeFacts.servicingData) newLoanStates: List<LoanStateMetadata>): ServicingData {
+        val updatedServicingData = ServicingData.newBuilder().mergeFrom(existingServicingData)
         validateRequirements {
-            for (state in newLoanStates.loanStateList) {
+            for (state in newLoanStates) {
                 requireThat(
-                    state.effectiveTime.isValid()      orError "Invalid effective time",
-                    state.servicerName.isNotBlank()    orError "Missing servicer name",
-                    state.totalUnpaidPrinBal.isValid() orError "Invalid total unpaid principal balance",
-                    state.accruedInterest.isValid()    orError "Invalid accrued interest",
-                    state.dailyIntAmount.isValid()     orError "Invalid daily interest amount",
+                    state.id.isValid()              orError "Invalid id",
+                    state.effectiveTime.isValid()   orError "Invalid effective time",
+                    state.uri.isNotBlank()          orError "Invalid accrued interest",
+                    state.checksum.isValid()        orError "Invalid checksum"
                 )
-                if (existingLoanStates.loanStateList.none { it.effectiveTime == state.effectiveTime }) {
-                    newLoanStateList.addLoanState(state)
+                if (existingServicingData.loanStateList.none { it.effectiveTime == state.effectiveTime }) {
+                    updatedServicingData.addLoanState(state)
                 }
             }
         }
-        return newLoanStateList.build()
+        return updatedServicingData.build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -14,9 +14,9 @@ import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.LoanDocuments
-import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStates
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.ValidationResults
+import tech.figure.validation.v1beta1.LoanValidation
 
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
@@ -62,12 +62,12 @@ open class RecordLoanContract(
     open fun recordDocuments(@Input(LoanScopeFacts.documents) documents: LoanDocuments) = documents
 
     @Function(invokedBy = PartyType.OWNER)
-    @Record(LoanScopeFacts.loanStates)
-    open fun recordLoanStates(@Input(LoanScopeFacts.loanStates) loanStates: LoanStates) = loanStates
+    @Record(LoanScopeFacts.servicingData)
+    open fun recordLoanStates(@Input(LoanScopeFacts.servicingData) servicingData: ServicingData) = servicingData
 
     @Function(invokedBy = PartyType.OWNER)
-    @Record(LoanScopeFacts.validationResults)
-    open fun recordValidationResults(@Input(LoanScopeFacts.validationResults) validationResults: ValidationResults) = validationResults
+    @Record(LoanScopeFacts.loanValidations)
+    open fun recordValidationResults(@Input(LoanScopeFacts.loanValidations) loanValidations: LoanValidation) = loanValidations
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -8,18 +8,17 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
-import tech.figure.validation.v1beta1.Validation
+import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationRequest
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Add/Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationRequestContract(
-    @Record(LoanScopeFacts.validationResults) val existingResults: Validation,
+    @Record(LoanScopeFacts.loanValidations) val existingResults: LoanValidation,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Add/Change to VALIDATOR?
-    @Record(LoanScopeFacts.validationResults)
+    @Record(LoanScopeFacts.loanValidations)
     open fun recordLoanValidationRequest(@Input(name = "newRequest") newRequest: ValidationRequest) { // TODO: Change signature & annotations
-
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -5,26 +5,26 @@ import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
-import io.provenance.scope.loan.LoanScopeFacts
-import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.validateRequirements
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
-import io.provenance.scope.loan.proto.ValidationResultSubmission
+import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
-import tech.figure.validation.v1beta1.Validation
+import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta1.ValidationResponse
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationResultsContract(
-    @Record(LoanScopeFacts.validationResults) val validationRecord: Validation,
+    @Record(LoanScopeFacts.loanValidations) val validationRecord: LoanValidation,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Change to VALIDATOR?
-    @Record(LoanScopeFacts.validationResults)
+    @Record(LoanScopeFacts.loanValidations)
     open fun recordLoanValidationResults(
-        @Input(name = "resultSubmission") submission: ValidationResultSubmission
-    ): Validation {
+        @Input(name = "resultSubmission") submission: ValidationResponse
+    ): LoanValidation {
         validateRequirements {
             requireThat(
                 submission.results.resultSetUuid.isValid()          orError "Result set UUID is missing",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -6,9 +6,9 @@ import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
-import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -18,7 +18,7 @@ import io.provenance.scope.loan.utility.validateRequirements
 open class UpdateENoteContract(
     @Record(LoanScopeFacts.eNote) val existingENote: ENote?, // TODO: Confirm if this should be nullable and adjust code below accordingly
 ) : P8eContract() {
-    @Function(invokedBy = PartyType.OWNER)  // TODO: Replace OWNER with CONTROLLER
+    @Function(invokedBy = PartyType.OWNER) // TODO: Replace OWNER with CONTROLLER
     @Record(LoanScopeFacts.eNote)
     open fun updateENote(@Input(name = "newENote") newENote: tech.figure.util.v1beta1.DocumentMetadata): ENote {
         validateRequirements(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
@@ -7,9 +7,9 @@ import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
-import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements


### PR DESCRIPTION
- Using camel case for Record names
- Swapped LoanStates for ServicingData and Validation for LoanValidation