### PR TITLE
Fix validation tests, remove deprecated proto

### DIFF
--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -4,18 +4,18 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.string.shouldContain
-import io.provenance.scope.loan.proto.ValidationResultSubmission
 import io.provenance.scope.loan.test.Constructors.contractWithEmptyExistingValidationRecord
 import io.provenance.scope.loan.test.Constructors.contractWithSingleValidationIteration
 import io.provenance.scope.loan.test.Constructors.randomProtoUuid
 import io.provenance.scope.loan.test.Constructors.validResultSubmission
 import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.validation.v1beta1.ValidationResponse
 
 class RecordLoanValidationResultsUnitTest : WordSpec({
     "recordLoanValidationResults" When {
         "given an invalid input" should {
             "throw an appropriate exception" {
-                ValidationResultSubmission.getDefaultInstance().let { emptyResultSubmission ->
+                ValidationResponse.getDefaultInstance().let { emptyResultSubmission ->
                     shouldThrow<ContractViolationException> {
                         contractWithEmptyExistingValidationRecord.apply {
                             recordLoanValidationResults(emptyResultSubmission)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -1,11 +1,11 @@
 package io.provenance.scope.loan.test
 
 import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
-import io.provenance.scope.loan.proto.ValidationResultSubmission
 import io.provenance.scope.util.toProtoTimestamp
-import tech.figure.validation.v1beta1.Validation
+import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationIteration
 import tech.figure.validation.v1beta1.ValidationRequest
+import tech.figure.validation.v1beta1.ValidationResponse
 import java.time.OffsetDateTime
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
@@ -17,10 +17,10 @@ object Constructors {
 
     val contractWithEmptyExistingValidationRecord: RecordLoanValidationResultsContract
         get() = RecordLoanValidationResultsContract(
-            Validation.getDefaultInstance()
+            LoanValidation.getDefaultInstance()
         )
     fun contractWithSingleValidationIteration(requestID: FigureTechUUID) = RecordLoanValidationResultsContract(
-        Validation.newBuilder().also { validationRecordBuilder ->
+        LoanValidation.newBuilder().also { validationRecordBuilder ->
             validationRecordBuilder.clearIteration()
             validationRecordBuilder.addIteration(
                 ValidationIteration.newBuilder().also { iterationBuilder ->
@@ -33,7 +33,7 @@ object Constructors {
             )
         }.build()
     )
-    fun validResultSubmission(iterationRequestID: FigureTechUUID) = ValidationResultSubmission.newBuilder().apply {
+    fun validResultSubmission(iterationRequestID: FigureTechUUID) = ValidationResponse.newBuilder().apply {
         requestId = iterationRequestID
         // TODO: Set remaining fields
     }.build()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataExtensionsTest.kt
@@ -74,10 +74,10 @@ class DataExtensionsTest : WordSpec({
             }.build().isValid() shouldBe false
         }
         "return true for any non-empty string" {
-            forAll(Arb.string(minSize = 1)) { randomString ->
+            forAll(Arb.string()) { randomString ->
                 FigureTechChecksum.newBuilder().apply {
                     checksum = randomString
-                }.build().isValid()
+                }.build().isValid() == randomString.isNotBlank()
             }
         }
     }

--- a/proto/src/main/proto/io/provenance/scope/loan/inputs.proto
+++ b/proto/src/main/proto/io/provenance/scope/loan/inputs.proto
@@ -4,11 +4,3 @@ package io.provenance.scope.loan.proto;
 
 option java_multiple_files = true;
 option java_package = "io.provenance.scope.loan.proto";
-
-import "tech/figure/util/v1beta1/types.proto";
-import "tech/figure/validation/v1beta1/validation.proto";
-
-message ValidationResultSubmission {
-  tech.figure.util.v1beta1.UUID                    request_id = 1;
-  tech.figure.validation.v1beta1.ValidationResults results    = 2;
-}


### PR DESCRIPTION
### Context
![Screenshot at Apr 29 11-15-11](https://user-images.githubusercontent.com/82118011/165984587-5483d1db-8319-4cab-b550-fb73b35b8496.png)
### Changes
- Fix build errors from tests broken by #10
- Remove protobuf definition deprecated by https://github.com/provenance-io/metadata-asset-model/pull/9
- Fix edge case in data extensions test