### PR TITLE
Clean up build files, update comments, add IllegalContractStateException

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,10 @@ import io.provenance.p8e.plugin.P8eLocationExtension
 import io.provenance.p8e.plugin.P8ePartyExtension
 
 buildscript {
-    dependencies {
-        classpathSpecs(
-            Dependencies.SemVer,
-            Dependencies.GitHubRelease,
-        )
-    }
+    classpathSpecs(
+        Dependencies.SemVer,
+        Dependencies.GitHubRelease,
+    )
     repositories {
         mavenCentral()
         maven { url = uri(RepositoryLocations.JitPack) }
@@ -42,6 +40,20 @@ allprojects {
     repositories {
         mavenCentral()
     }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    tasks.withType<KotlinCompile>().all {
+        sourceCompatibility = "11"
+        sourceCompatibility = "11"
+        kotlinOptions {
+            languageVersion = "1.6"
+            jvmTarget = "11"
+        }
+    }
 }
 
 subprojects {
@@ -53,12 +65,6 @@ subprojects {
     java {
         withJavadocJar()
         withSourcesJar()
-    }
-
-    tasks.withType<KotlinCompile>().all {
-        kotlinOptions {
-            jvmTarget = "11"
-        }
     }
 
     publishing {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -11,6 +11,9 @@ import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.validation.v1beta1.LoanValidation
 
+/**
+ * Denotes the string literals used in [Record] annotations for the [LoanScopeSpecification] and its contracts.
+ */
 object LoanScopeFacts {
     const val asset = "asset"
     const val documents = "documents"
@@ -20,15 +23,38 @@ object LoanScopeFacts {
     const val eNote = "eNote"
 }
 
+/**
+ * Denotes the string literals used in [io.provenance.scope.contract.annotations.Input] annotations for
+ * [LoanScopeSpecification] contract functions where the input type differs from the output type.
+ */
+object LoanScopeInputs {
+    const val validationRequest = "newRequest"
+    const val validationResponse = "resultSubmission"
+    const val eNoteUpdate = "newENote"
+    const val eNoteControllerUpdate = "newController"
+}
+
+/**
+ * Denotes the [Record]s that are part of a [LoanScopeSpecification] for the loan package.
+ */
 data class LoanPackage(
+    /** The loan asset. */
     @Record(LoanScopeFacts.asset) var asset: Asset,
-    @Record(LoanScopeFacts.servicingRights) var servicingRights: ServicingRights, // Defaults to the lender
-    @Record(LoanScopeFacts.documents) var documents: LoanDocuments? = null, // list of document metadata with URIs that point to documents in EOS
-    @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData? = null, // list of loan state metadata
-    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation? = null, // object containing list of third party validation results and a summary of exceptions
+    /** The servicing rights to the loan. Defaults to the lender. */
+    @Record(LoanScopeFacts.servicingRights) var servicingRights: ServicingRights,
+    /** A list of metadata for documents, including their URIs in an encrypted object store. */
+    @Record(LoanScopeFacts.documents) var documents: LoanDocuments? = null,
+    /** Servicing data for the loan, including a list of metadata on loan states. */
+    @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData? = null,
+    /** A list of third-party validation iterations. */
+    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation? = null,
+    /** The eNote for the loan. */
     @Record(LoanScopeFacts.eNote) var eNote: ENote? = null
 )
 
+/**
+ * The scope specification definition for a [LoanPackage].
+ */
 @ScopeSpecificationDefinition(
     uuid = "c370d852-0f3b-4f70-85e6-25983ac07c0f",
     name = "tech.figure.loan",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocContract.kt
@@ -1,6 +1,5 @@
 package io.provenance.scope.loan.contracts
 
-import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.annotations.Function
 import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
@@ -8,6 +7,8 @@ import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -23,16 +24,18 @@ open class AppendLoanDocContract(
     @Record(LoanScopeFacts.documents)
     open fun appendDocuments(@Input(LoanScopeFacts.documents) newDocs: LoanDocuments): LoanDocuments {
         val newDocList = LoanDocuments.newBuilder().mergeFrom(existingDocs)
-        for (doc in newDocs.documentList) {
-            validateRequirements(
-                doc.id.isValid()              orError "Document missing ID",
-                doc.uri.isNotBlank()          orError "Document with ID ${doc.id} is missing uri",
-                doc.contentType.isNotBlank()  orError "Document with ID ${doc.id} is missing content type",
-                doc.documentType.isNotBlank() orError "Document with ID ${doc.id} is missing document type",
-                doc.checksum.isValid()        orError "Document with ID ${doc.id} is missing checksum",
-            )
-            if (!existingDocs.documentList.any { it.checksum == doc.checksum }) { // TODO: Improve efficiency of this
-                newDocList.addDocument(doc)
+        validateRequirements(VALID_INPUT) {
+            for (doc in newDocs.documentList) {
+                requireThat(
+                    doc.id.isValid()              orError "Document missing ID",
+                    doc.uri.isNotBlank()          orError "Document with ID ${doc.id} is missing URI",
+                    doc.contentType.isNotBlank()  orError "Document with ID ${doc.id} is missing content type",
+                    doc.documentType.isNotBlank() orError "Document with ID ${doc.id} is missing document type",
+                    doc.checksum.isValid()        orError "Document with ID ${doc.id} is missing checksum",
+                )
+                if (!existingDocs.documentList.any { it.checksum == doc.checksum }) { // TODO: Improve efficiency of this
+                    newDocList.addDocument(doc)
+                }
             }
         }
         return newDocList.build()

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -8,6 +8,7 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -24,7 +25,7 @@ open class AppendLoanStatesContract(
     @Record(LoanScopeFacts.servicingData)
     open fun appendLoanStates(@Input(LoanScopeFacts.servicingData) newLoanStates: List<LoanStateMetadata>): ServicingData {
         val updatedServicingData = ServicingData.newBuilder().mergeFrom(existingServicingData)
-        validateRequirements {
+        validateRequirements(VALID_INPUT) {
             for (state in newLoanStates) {
                 requireThat(
                     state.id.isValid()              orError "Invalid id",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -9,6 +9,7 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -20,7 +21,7 @@ open class RecordENoteContract: P8eContract() {
     @Function(invokedBy = Specifications.PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
-        validateRequirements(
+        validateRequirements(VALID_INPUT,
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
             eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
             eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -9,6 +9,7 @@ import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -29,7 +30,7 @@ open class RecordLoanContract(
     @Record(LoanScopeFacts.asset)
     open fun recordAsset(@Input(LoanScopeFacts.asset) asset: Asset) = asset.also {
         // TODO: Add or implement correct extension for safe casting of kvMap values like "loan"
-        /*validateRequirements {
+        /*validateRequirements(VALID_INPUT) {
             if (existingAsset != null) {
                 requireThat(
                     // Flag that the asset is an eNote
@@ -72,9 +73,11 @@ open class RecordLoanContract(
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote? = null) = eNote?.also {
-        validateRequirements {
+        validateRequirements(VALID_INPUT) {
             if (existingENote != null) {
-                requireThat((existingENote.eNote.checksum == it.eNote.checksum) orError "ENote with a different checksum already exists on chain for the specified scope; ENote modifications are not allowed!")
+                requireThat((existingENote.eNote.checksum == it.eNote.checksum) orError
+                    "ENote with a different checksum already exists on chain for the specified scope; ENote modifications are not allowed!"
+                )
             }
             // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
             requireThat(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -8,6 +8,7 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeInputs
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationRequest
 
@@ -19,6 +20,6 @@ open class RecordLoanValidationRequestContract(
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Add/Change to VALIDATOR?
     @Record(LoanScopeFacts.loanValidations)
-    open fun recordLoanValidationRequest(@Input(name = "newRequest") newRequest: ValidationRequest) { // TODO: Change signature & annotations
+    open fun recordLoanValidationRequest(@Input(LoanScopeInputs.validationRequest) newRequest: ValidationRequest) {
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -8,24 +8,26 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationResponse
 
-@Participants(roles = [PartyType.OWNER]) // TODO: Change to VALIDATOR?
+@Participants(roles = [PartyType.OWNER]) // TODO: Ensure Authz grant to validator has been made
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationResultsContract(
     @Record(LoanScopeFacts.loanValidations) val validationRecord: LoanValidation,
 ) : P8eContract() {
 
-    @Function(invokedBy = PartyType.OWNER) // TODO: Change to VALIDATOR?
+    @Function(invokedBy = PartyType.OWNER) // TODO: Ensure Authz grant to validator has been made
     @Record(LoanScopeFacts.loanValidations)
     open fun recordLoanValidationResults(
-        @Input(name = "resultSubmission") submission: ValidationResponse
+        @Input(LoanScopeInputs.validationResponse) submission: ValidationResponse
     ): LoanValidation {
-        validateRequirements {
+        validateRequirements(VALID_INPUT) {
             requireThat(
                 submission.results.resultSetUuid.isValid()          orError "Result set UUID is missing",
                 submission.requestId.isValid()                      orError "Request ID is missing",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -14,6 +14,7 @@ import io.provenance.scope.loan.utility.ContractRequirementType
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.util.v1beta1.DocumentMetadata
 // TODO: Potentially remove in favor of append model rather than blanket overwrite
 @Participants(roles = [PartyType.OWNER]) // TODO: Change to controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
@@ -23,7 +24,7 @@ open class UpdateENoteContract(
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
-    open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: tech.figure.util.v1beta1.DocumentMetadata): ENote {
+    open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: DocumentMetadata): ENote {
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
             (existingENote !== null) orError "Cannot create eNote using this contract",
         )

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -9,20 +9,25 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
-
-@Participants(roles = [PartyType.OWNER]) // TODO: Replace OWNER with CONTROLLER
+// TODO: Potentially remove in favor of append model rather than blanket overwrite
+@Participants(roles = [PartyType.OWNER]) // TODO: Change to controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteContract(
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote?, // TODO: Confirm if this should be nullable and adjust code below accordingly
+    @Record(LoanScopeFacts.eNote) val existingENote: ENote?,
 ) : P8eContract() {
-    @Function(invokedBy = PartyType.OWNER) // TODO: Replace OWNER with CONTROLLER
+
+    @Function(invokedBy = PartyType.OWNER) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
-    open fun updateENote(@Input(name = "newENote") newENote: tech.figure.util.v1beta1.DocumentMetadata): ENote {
-        validateRequirements(
-            (existingENote !== null)           orError "Cannot create eNote using this contract",
+    open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: tech.figure.util.v1beta1.DocumentMetadata): ENote {
+        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
+            (existingENote !== null) orError "Cannot create eNote using this contract",
+        )
+        validateRequirements(ContractRequirementType.VALID_INPUT,
             newENote.id.isValid()              orError "ENote missing ID",
             newENote.uri.isNotBlank()          orError "ENote missing uri",
             newENote.contentType.isNotBlank()  orError "ENote missing content type",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
@@ -10,20 +10,25 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 
-@Participants([PartyType.OWNER/*, PartyType.CONTROLLER*/]) // TODO: Specify both OWNER and CONTROLLER
+@Participants([PartyType.OWNER/*, PartyType.CONTROLLER*/]) // TODO: Add controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteControllerContract(
     @Record(LoanScopeFacts.eNote) val existingENote: ENote?, // TODO: Confirm if this should be nullable and adjust code below accordingly
 ) : P8eContract() {
-    @Function(invokedBy = PartyType.OWNER/*PartyType.CONTROLLER*/) // TODO: Replace OWNER with CONTROLLER
+
+    @Function(invokedBy = PartyType.OWNER/*PartyType.CONTROLLER*/) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
-    open fun updateENoteController(@Input(name = "newController") newController: Controller): ENote {
-        validateRequirements(
-            (existingENote !== null)                  orError "Cannot create eNote using this contract",
+    open fun updateENoteController(@Input(LoanScopeInputs.eNoteControllerUpdate) newController: Controller): ENote {
+        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
+            (existingENote !== null) orError "Cannot create eNote using this contract",
+        )
+        validateRequirements(ContractRequirementType.VALID_INPUT,
             newController.controllerUuid.isValid()    orError "Controller UUID is missing",
             newController.controllerName.isNotBlank() orError "Controller Name is missing",
         )

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateServicingRightsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateServicingRightsContract.kt
@@ -8,6 +8,7 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -16,10 +17,11 @@ import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateServicingRightsContract : P8eContract() {
+
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingRights)
     open fun updateServicingRights(@Input(LoanScopeFacts.servicingRights) servicingRights: ServicingRights) = servicingRights.also {
-        validateRequirements(
+        validateRequirements(VALID_INPUT,
             servicingRights.servicerId.isValid()      orError "Missing servicer UUID",
             servicingRights.servicerName.isNotBlank() orError "Missing servicer name",
         )

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -16,9 +16,53 @@ internal typealias ContractEnforcement = Pair<Boolean, ContractViolation>
 internal typealias ContractViolationMap = MutableMap<ContractViolation, UInt>
 
 /**
- * Denotes an [Exception] thrown by [validateRequirements] when at least one [ContractViolation] is found.
+ * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed for an inapplicable loan scope.
  */
-internal class ContractViolationException(val overallViolationCount: UInt, message: String) : IllegalArgumentException(message)
+class IllegalContractStateException(message: String) : IllegalStateException(message)
+
+/**
+ * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed with invalid input.
+ */
+class ContractViolationException(val overallViolationCount: UInt, message: String) : IllegalArgumentException(message)
+
+/**
+ * Denotes the type of contract requirement being evaluated by [validateRequirements].
+ */
+internal enum class ContractRequirementType(
+    val toException: (UInt, String) -> Exception,
+) {
+    /**
+     * A requirement for the state of a scope in order for a given contract to execute.
+     */
+    LEGAL_SCOPE_STATE({ violationCount, violations ->
+        when (violationCount) {
+            0U -> ""
+            1U -> " - $violationCount violation was found"
+            else ->  " - $violationCount violations were found"
+        }.let { violationCountSnippet ->
+            IllegalContractStateException(
+                "The contract state was invalid$violationCountSnippet" +
+                    if (violations.isNotBlank()) ": $violations" else ""
+            )
+        }
+    }),
+    /**
+     * A requirement for the input to a given contract in order for it to execute.
+     */
+    VALID_INPUT({ violationCount, violations ->
+        when (violationCount) {
+            0U -> ""
+            1U -> " - $violationCount unique violation was found"
+            else ->  " - $violationCount unique violations were found"
+        }.let { violationCountSnippet ->
+            ContractViolationException(
+                violationCount,
+                "The contract input was invalid$violationCountSnippet" +
+                    if (violations.isNotBlank()) ": $violations" else ""
+            )
+        }
+    }),
+}
 
 /**
  * Maps a contract requirement to the appropriate [ContractViolation] that should be raised if it is not met.
@@ -31,22 +75,27 @@ internal infix fun Boolean.orError(error: ContractViolation): ContractEnforcemen
  * Performs validation of one or more [ContractEnforcement]s.
  */
 internal fun validateRequirements(
-    vararg checks: ContractEnforcement
+    requirementType: ContractRequirementType,
+    vararg checks: ContractEnforcement,
 ) = checks.fold<ContractEnforcement, ContractViolationMap>(mutableMapOf()) { acc, (rule, violationReport) ->
         acc.apply {
             if (!rule) {
                 acc[violationReport] = acc.getOrDefault(violationReport, 0U) + 1U
             }
         }
-    }.handleViolations()
+    }.handleViolations(requirementType)
 
 /**
- * Performs validation of any [ContractEnforcement]s specified by [requireThat] in the body.
- * Should be used to wrap code blocks that also performs actions other than validation.
+ * Performs validation of any [ContractEnforcement]s specified by [ContractEnforcementContext.requireThat] in the body.
+ * Should be used to wrap code bodies that also performs actions other than validation.
+ *
+ * @param requirementType The type of validation being performed.
+ * @param checksBody a body of code which contains calls to [ContractEnforcementContext.requireThat].
  */
 internal fun validateRequirements(
-    checksBody: ContractEnforcementContext.() -> Unit
-) = ContractEnforcementContext()
+    requirementType: ContractRequirementType,
+    checksBody: ContractEnforcementContext.() -> Unit,
+) = ContractEnforcementContext(requirementType)
     .apply(checksBody)
     .handleViolations()
 
@@ -54,28 +103,37 @@ internal fun validateRequirements(
  * Aggregates multiple [ContractEnforcement]s into a single exception listing all of the [ContractViolation]s that
  * were found.
  *
- * @throws [ContractViolationException] if any of the supplied contract requirements were violated.
+ * @throws [Exception] if any of the supplied contract requirements were violated.
  * @return [Nothing] if no contract requirements were violated.
  */
-private fun ContractViolationMap.handleViolations() =
-    entries.fold(
+private fun ContractViolationMap.handleViolations(
+    requirementType: ContractRequirementType,
+) = entries.fold(
         "" to 0U
     ) { (violationMessage, overallViolationCount), (violation, count) ->
         if (count > 0U) {
-            "$violationMessage; $violation ($count occurrences)" to overallViolationCount + 1U
+            if (count > 1U) {
+                "$violation ($count occurrences)"
+            } else {
+                violation
+            }.let { violationInstance ->
+                "$violationMessage${if (overallViolationCount > 0U) ", " else ""} $violationInstance" to overallViolationCount + 1U
+            }
         } else {
             violationMessage to overallViolationCount
         }
     }.takeIf { (_, overallViolationCount) ->
         overallViolationCount > 0U
     }?.let { (formattedViolations, overallViolationCount) ->
-        throw ContractViolationException(
-            overallViolationCount,
-            "The contract input was invalid - $overallViolationCount unique violations were found: $formattedViolations"
-        )
+        throw requirementType.toException(overallViolationCount, formattedViolations)
     }
 
-internal class ContractEnforcementContext {
+/**
+ * Defines a body in which [ContractEnforcement]s can be freely defined and then collectively evaluated.
+ */
+internal class ContractEnforcementContext(
+    val requirementType: ContractRequirementType,
+) {
     /**
      * A [ContractViolationMap] which can be updated by calls to [requireThat].
      */
@@ -91,5 +149,5 @@ internal class ContractEnforcementContext {
     /**
      * See [io.provenance.scope.loan.utility.handleViolations].
      */
-    fun handleViolations() = violations.handleViolations()
+    fun handleViolations() = violations.handleViolations(requirementType)
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataExtensions.kt
@@ -13,7 +13,7 @@ private fun tryOrFalse(fn: () -> Any): Boolean =
     try {
         fn()
         true
-    } catch (e: Exception) {
+    } catch (ignored: Exception) {
         false
     }
 
@@ -23,7 +23,7 @@ internal fun ProtobufTimestamp?.isValid() = isSet()
 
 internal fun FigureTechDate?.isValid() = isSet() && this!!.value.isNotBlank()
 
-internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank()
+internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank() // Check for algorithm is omitted
 
 internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse {
     JavaUUID.fromString(this.value)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainIgnoringCase
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.list
@@ -41,25 +42,72 @@ class ContractRequirementsTest : WordSpec({
                     (rule orError violationReport) shouldBe ContractEnforcement(rule, violationReport)
                 }
             }
-            "return violations only for failed conditions" {
+            "return state violations only for failed conditions" {
+                checkAll(Arb.list(LoanPackageArbs.contractEnforcement)) { enforcementList ->
+                    val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
+                    if (expectedOverallViolationCount > 0U) {
+                        shouldThrow<IllegalContractStateException> {
+                            validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE, *enforcementList.toTypedArray())
+                        }.let { exception ->
+                            exception.message shouldContainIgnoringCase "state was invalid" // TODO: Make better check
+                        }
+                    } else {
+                        shouldNotThrow<IllegalContractStateException> {
+                            validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE, *enforcementList.toTypedArray())
+                        }
+                    }
+                }
+            }
+            "return input violations only for failed conditions" {
                 checkAll(Arb.list(LoanPackageArbs.contractEnforcement)) { enforcementList ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<ContractViolationException> {
-                            validateRequirements(*enforcementList.toTypedArray())
+                            validateRequirements(ContractRequirementType.VALID_INPUT, *enforcementList.toTypedArray())
                         }.let { exception ->
                             exception shouldHaveViolationCount expectedOverallViolationCount
                         }
                     } else {
                         shouldNotThrow<ContractViolationException> {
-                            validateRequirements(*enforcementList.toTypedArray())
+                            validateRequirements(ContractRequirementType.VALID_INPUT, *enforcementList.toTypedArray())
                         }
                     }
                 }
             }
         }
         "invoked with a function body" should {
-            "return violations only for failed conditions" {
+            "return state violations only for failed conditions" {
+                checkAll(
+                    Arb.list(LoanPackageArbs.contractEnforcement),
+                    Arb.list(LoanPackageArbs.contractEnforcement),
+                ) { enforcementListA, enforcementListB ->
+                    val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
+                    if (expectedOverallViolationCount > 0U) {
+                        shouldThrow<IllegalContractStateException> {
+                            validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                                5 shouldBeGreaterThanOrEqual 4
+                                requireThat(*enforcementListA.toTypedArray())
+                                3 shouldBeLessThan 4
+                                requireThat(*enforcementListB.toTypedArray())
+                                2 shouldBeInRange 0..9
+                            }
+                        }.let { exception ->
+                            exception.message shouldContainIgnoringCase "state was invalid" // TODO: Make better check
+                        }
+                    } else {
+                        shouldNotThrow<ContractViolationException> {
+                            validateRequirements(ContractRequirementType.VALID_INPUT) {
+                                2 shouldBeInRange 0..9
+                                requireThat(*enforcementListB.toTypedArray())
+                                5 shouldBeGreaterThanOrEqual 4
+                                requireThat(*enforcementListA.toTypedArray())
+                                3 shouldBeLessThan 4
+                            }
+                        }
+                    }
+                }
+            }
+            "return input violations only for failed conditions" {
                 checkAll(
                     Arb.list(LoanPackageArbs.contractEnforcement),
                     Arb.list(LoanPackageArbs.contractEnforcement),
@@ -67,7 +115,7 @@ class ContractRequirementsTest : WordSpec({
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<ContractViolationException> {
-                            validateRequirements {
+                            validateRequirements(ContractRequirementType.VALID_INPUT) {
                                 5 shouldBeGreaterThanOrEqual 4
                                 requireThat(*enforcementListB.toTypedArray())
                                 3 shouldBeLessThan 4
@@ -79,11 +127,11 @@ class ContractRequirementsTest : WordSpec({
                         }
                     } else {
                         shouldNotThrow<ContractViolationException> {
-                            validateRequirements {
+                            validateRequirements(ContractRequirementType.VALID_INPUT) {
                                 2 shouldBeInRange 0..9
-                                requireThat(*enforcementListB.toTypedArray())
-                                5 shouldBeGreaterThanOrEqual 4
                                 requireThat(*enforcementListA.toTypedArray())
+                                5 shouldBeGreaterThanOrEqual 4
+                                requireThat(*enforcementListB.toTypedArray())
                                 3 shouldBeLessThan 4
                             }
                         }

--- a/proto/build.gradle.kts
+++ b/proto/build.gradle.kts
@@ -6,9 +6,9 @@ buildscript {
         mavenCentral()
     }
 
-    dependencies {
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.18")
-    }
+    classpathSpecs(
+        Plugins.GradleProtobuf,
+    )
 }
 
 plugins {


### PR DESCRIPTION
### Changes
- Clean up helper function usage for build files
- Explicitly specify language versions in root build file
- Add KDocs to `LoanScope` file
- Add `LoanScopeInputs` object for defining `@Input.name` values of contract functions with a different input parameter type than that of the `@Record` being updated
  - I kept the names the same for compatibility, but I would like to update them to be more precise in later PRs
- Update TODOs and a few other comments
- Implement a second exception type, `IllegalContractStateException`, to better distinguish between contract failure types
  - I added an enum `ContractRequirementType` to keep usage of `validateRequirements` clear and easy to follow
