### PR TITLE
Add linting & test result publishing, update README & workflows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+### Kotlin
+[*.{kt,kts}]
+# possible values: number (e.g. 2), "unset" (makes ktlint ignore indentation completely)
+indent_size=4
+# true (recommended) / false
+insert_final_newline=true
+# possible values: number (e.g. 120) (package name, imports & comments are ignored), "off"
+# it's automatically set to 100 on `ktlint --android ...` (per Android Kotlin Style Guide)
+max_line_length=145
+[contract/**/contracts/*.{kt, kts}]
+# Rules disabled to allow for easier readability of certain contract code
+disabled_rules=wrapping,no-multi-spaces
+[buildSrc/**.{kt, kts}]
+disabled_rules=filename

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,29 @@ name: Build
 
 on:
   pull_request:
-    branches:
-      - main
+    types: [ synchronize, opened, reopened, ready_for_review ]
 
 jobs:
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Linting
+        run: ./gradlew ktlintCheck --parallel
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -27,3 +46,31 @@ jobs:
 
       - name: Check Contract Syntax
         run: ./gradlew p8eClean p8eCheck --info
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test-results"
+          path: "**/build/test-results/**/*.xml"
+
+  publish_test_results:
+    name: Publish Test Results
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: "test-results"
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: "Test Results"
+          pull_request_build: "commit"
+          report_individual_runs: true
+          files: artifacts/**/*.xml

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -13,6 +13,26 @@ on:
           - 'mainnet'
 
 jobs:
+  linting:
+    name: Linting
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
+      - name: Linting
+        run: ./gradlew ktlintCheck --parallel
+
   build-and-publish:
     name: Build and Publish Jar
     runs-on: ubuntu-latest
@@ -68,3 +88,31 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: "test-results"
+          path: "**/build/test-results/**/*.xml"
+
+  publish_test_results:
+    name: Publish Test Results
+    needs: [ build-and-publish ]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: "test-results"
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: "Test Results"
+          pull_request_build: "commit"
+          report_individual_runs: true
+          files: artifacts/**/*.xml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # loan-package-contracts
-P8e Smart Contracts for use against loan package
+Defines a loan package scope definition and p8e smart contracts that can be executed against it
+## Development
+### Commands
+#### Cloning the Repository
+```shell
+git clone https://github.com/provenance-io/loan-package-contracts.git
+cd loan-package-contracts/
+```
+#### Building the project
+```shell
+./gradlew clean build --refresh-dependencies
+```
+#### Bootstrapping the contracts 
+```shell
+./gradlew p8eClean p8eCheck p8eBootstrap
+```
+See [here](https://github.com/provenance-io/p8e-gradle-plugin/#tasks) for details on the p8e tasks.
+#### Linting
+This project uses [Ktlint](https://github.com/pinterest/ktlint).
+
+To run the linter against your code, use
+```shell
+./gradlew ktlintCheck
+```
+To have the linter update your code to fit the linting rules, use
+```shell
+./gradlew ktlintFormat
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import io.provenance.p8e.plugin.P8eLocationExtension
 import io.provenance.p8e.plugin.P8ePartyExtension
 
+/** Build setup */
+
 buildscript {
     classpathSpecs(
         Dependencies.SemVer,
@@ -23,6 +25,44 @@ plugins {
     )
     signing
 }
+
+/** Ktlint */
+
+val ktlint by configurations.creating
+
+dependencies {
+    ktlint(Dependencies.Ktlint.toDependencyNotation()) {
+        attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+        }
+    }
+    // ktlint(project(":custom-ktlint-ruleset")) // in case of custom ruleset
+}
+
+val outputDir = "${project.buildDir}/reports/ktlint/"
+val inputFiles = project.fileTree(mapOf("dir" to "src", "include" to "**/*.kt"))
+
+val ktlintCheck by tasks.creating(JavaExec::class) {
+    inputs.files(inputFiles)
+    outputs.dir(outputDir)
+
+    description = "Check Kotlin code style."
+    classpath = ktlint
+    mainClass.set("com.pinterest.ktlint.Main")
+    args = listOf("*/src/**/*.kt")
+}
+
+val ktlintFormat by tasks.creating(JavaExec::class) {
+    inputs.files(inputFiles)
+    outputs.dir(outputDir)
+
+    description = "Fix Kotlin code style deviations."
+    classpath = ktlint
+    mainClass.set("com.pinterest.ktlint.Main")
+    args = listOf("-F", "*/src/**/*.kt")
+}
+
+/** Project Setup & Releasing */
 
 semver {
     tagPrefix("v")

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,12 +9,13 @@ object Versions {
     const val Kotlin = "1.6.21"
     const val GitHubRelease = "2.2.12"
     const val Kotest = "5.2.3"
+    const val Ktlint = "0.45.2"
     const val KrotoPlus = "0.6.1"
     object Plugins {
         const val NexusPublishing = "1.1.0"
         const val P8ePublishing = "0.6.4"
         const val Protobuf = "0.8.18"
-        const val SemVer = "0.3.10"
+        const val SemVer = "0.3.13"
     }
     object Dependencies {
         const val Grpc = "1.39.0"
@@ -65,7 +66,10 @@ object Dependencies {
             version = Versions.Kotest,
         )
     }
-
+    val Ktlint = DependencySpec(
+        name = "com.pinterest:ktlint",
+        version = Versions.Ktlint,
+    )
     // Dependencies
     object Grpc {
         val Stub = DependencySpec(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -16,7 +16,7 @@ import io.provenance.scope.loan.utility.validateRequirements
 
 @Participants(roles = [Specifications.PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
-open class RecordENoteContract: P8eContract() {
+open class RecordENoteContract : P8eContract() {
 
     @Function(invokedBy = Specifications.PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -4,8 +4,8 @@ import io.dartinc.registry.v1beta1.ENote
 import io.provenance.scope.contract.annotations.Function
 import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
-import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -5,9 +5,9 @@ import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
-import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationRequest

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -38,7 +38,7 @@ internal enum class ContractRequirementType(
         when (violationCount) {
             0U -> ""
             1U -> " - $violationCount violation was found"
-            else ->  " - $violationCount violations were found"
+            else -> " - $violationCount violations were found"
         }.let { violationCountSnippet ->
             IllegalContractStateException(
                 "The contract state was invalid$violationCountSnippet" +
@@ -53,7 +53,7 @@ internal enum class ContractRequirementType(
         when (violationCount) {
             0U -> ""
             1U -> " - $violationCount unique violation was found"
-            else ->  " - $violationCount unique violations were found"
+            else -> " - $violationCount unique violations were found"
         }.let { violationCountSnippet ->
             ContractViolationException(
                 violationCount,
@@ -77,7 +77,8 @@ internal infix fun Boolean.orError(error: ContractViolation): ContractEnforcemen
 internal fun validateRequirements(
     requirementType: ContractRequirementType,
     vararg checks: ContractEnforcement,
-) = checks.fold<ContractEnforcement, ContractViolationMap>(mutableMapOf()) { acc, (rule, violationReport) ->
+) =
+    checks.fold<ContractEnforcement, ContractViolationMap>(mutableMapOf()) { acc, (rule, violationReport) ->
         acc.apply {
             if (!rule) {
                 acc[violationReport] = acc.getOrDefault(violationReport, 0U) + 1U
@@ -108,7 +109,8 @@ internal fun validateRequirements(
  */
 private fun ContractViolationMap.handleViolations(
     requirementType: ContractRequirementType,
-) = entries.fold(
+) =
+    entries.fold(
         "" to 0U
     ) { (violationMessage, overallViolationCount), (violation, count) ->
         if (count > 0U) {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
@@ -12,8 +12,8 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.list
 import io.kotest.property.checkAll
-import io.provenance.scope.loan.test.shouldHaveViolationCount
 import io.provenance.scope.loan.test.LoanPackageArbs
+import io.provenance.scope.loan.test.shouldHaveViolationCount
 
 class ContractRequirementsTest : WordSpec({
     /* Helpers */


### PR DESCRIPTION
### Context
I figured this repository could benefit from having a linter, but I felt that certain logic in the contract classes (specifically the calls to `validateRequirements`) is greatly benefiting from "irregular" spacing for the sake of readability, so I wanted to keep the rules lax for those files.
### Changes
- Add Ktlint to project build and CI workflows
  - Rule exceptions defined in `.editorconfig`
  - Runs in CI on commit to a non-draft PR or in the release job
- Add test result publishing to CI workflows
  - **Note that it will not work for PRs from forks unless the workaround outlined [here](https://github.com/EnricoMi/publish-unit-test-result-action/blob/master/README.md#support-fork-repositories-and-dependabot-branches) is implemented, however I would like to avoid doing so for now due to the dangers referenced [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).**
- Change build workflow to run on any pull request and also run when converted from draft to ready for review
- Fix existing linting issues
- Updated README with basic command usage
- Bump semver from `0.3.10` to `0.3.13`