### PR TITLE
Clean up more project files & fix some code smells

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: '11'
 
       - name: Linting
-        run: ./gradlew ktlintCheck --parallel
+        run: ./gradlew clean ktlintCheck --parallel
 
   build:
     name: Build

--- a/.github/workflows/release-build-publish.yml
+++ b/.github/workflows/release-build-publish.yml
@@ -31,7 +31,7 @@ jobs:
           java-version: '11'
 
       - name: Linting
-        run: ./gradlew ktlintCheck --parallel
+        run: ./gradlew clean ktlintCheck --parallel
 
   build-and-publish:
     name: Build and Publish Jar

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,12 @@ build/
 .project
 .classpath
 
+# p8e files
+ContractHash*.kt
+ProtoHash*.kt
+**/resources/**/*.ContractHash
+**/resources/**/*.ProtoHash
+
 # Miscellaneous files
 /bin/
 out/

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ See [here](https://github.com/provenance-io/p8e-gradle-plugin/#tasks) for detail
 #### Linting
 This project uses [Ktlint](https://github.com/pinterest/ktlint).
 
-To run the linter against your code, use
+To immediately view linting errors, use
+```shell
+./gradlew clean ktlintCheck
+```
+To generate linting reports, use
 ```shell
 ./gradlew ktlintCheck
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,16 @@ dependencies {
 
 val outputDir = "${project.buildDir}/reports/ktlint/"
 val inputFiles = project.fileTree(mapOf("dir" to "src", "include" to "**/*.kt"))
+val lintingExclusions = listOf(
+    "**/ContractHash*.kt",
+    "**/ProtoHash*.kt",
+)
+
+val ktlintExcludeSyntax: (Collection<String>) -> Collection<String> = { exclusions ->
+    exclusions.map { exclusion ->
+        "!$exclusion"
+    }
+}
 
 val ktlintCheck by tasks.creating(JavaExec::class) {
     inputs.files(inputFiles)
@@ -49,7 +59,7 @@ val ktlintCheck by tasks.creating(JavaExec::class) {
     description = "Check Kotlin code style."
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    args = listOf("*/src/**/*.kt")
+    args = listOf("*/src/**/*.kt") + ktlintExcludeSyntax(lintingExclusions)
 }
 
 val ktlintFormat by tasks.creating(JavaExec::class) {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -16,16 +16,6 @@ internal typealias ContractEnforcement = Pair<Boolean, ContractViolation>
 internal typealias ContractViolationMap = MutableMap<ContractViolation, UInt>
 
 /**
- * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed for an inapplicable loan scope.
- */
-class IllegalContractStateException(message: String) : IllegalStateException(message)
-
-/**
- * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed with invalid input.
- */
-class ContractViolationException(val overallViolationCount: UInt, message: String) : IllegalArgumentException(message)
-
-/**
  * Denotes the type of contract requirement being evaluated by [validateRequirements].
  */
 internal enum class ContractRequirementType(
@@ -115,9 +105,9 @@ private fun ContractViolationMap.handleViolations(
     ) { (violationMessage, overallViolationCount), (violation, count) ->
         if (count > 0U) {
             if (count > 1U) {
-                "$violation ($count occurrences)"
+                "\"$violation\" ($count occurrences)"
             } else {
-                violation
+                "\"$violation\""
             }.let { violationInstance ->
                 "$violationMessage${if (overallViolationCount > 0U) ", " else ""} $violationInstance" to overallViolationCount + 1U
             }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -19,7 +19,9 @@ private fun tryOrFalse(fn: () -> Any): Boolean =
 
 internal fun ProtobufMessage?.isSet() = this !== null && this != this.defaultInstanceForType
 
-internal fun ProtobufTimestamp?.isValid() = isSet()
+internal fun ProtobufMessage?.isNotSet() = !isSet()
+
+internal fun ProtobufTimestamp?.isValid() = this !== null // Make no assumptions about validity of epoch on behalf of the data source
 
 internal fun FigureTechDate?.isValid() = isSet() && this!!.value.isNotBlank()
 
@@ -29,4 +31,4 @@ internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() &&
     JavaUUID.fromString(this.value)
 }
 
-internal fun FigureTechMoney?.isValid() = isSet()
+internal fun FigureTechMoney?.isValid() = this !== null // Make no assumptions about validity of money amount on behalf of the data source

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/Exceptions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/Exceptions.kt
@@ -1,0 +1,18 @@
+package io.provenance.scope.loan.utility
+
+/**
+ * Denotes an [Exception] thrown when a contract's assumptions are violated.
+ */
+class UnexpectedContractStateException(message: String, cause: Exception?) : IllegalStateException(message, cause) {
+    constructor(message: String) : this(message, null)
+}
+
+/**
+ * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed for an inapplicable loan scope.
+ */
+class IllegalContractStateException(message: String) : IllegalStateException(message)
+
+/**
+ * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed with invalid input.
+ */
+class ContractViolationException(val overallViolationCount: UInt, message: String) : IllegalArgumentException(message)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsTest.kt
@@ -1,7 +1,6 @@
 package io.provenance.scope.loan.utility
 
 import com.google.protobuf.Any
-import com.google.protobuf.Timestamp
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -16,14 +15,13 @@ import io.provenance.scope.loan.test.Constructors.randomProtoUuid
 import io.provenance.scope.util.toProtoTimestamp
 import tech.figure.validation.v1beta1.ValidationIteration
 import tech.figure.validation.v1beta1.ValidationRequest
-import java.time.LocalDateTime
 import java.time.ZoneOffset
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.Money as FigureTechMoney
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
-class DataExtensionsTest : WordSpec({
+class DataValidationExtensionsTest : WordSpec({
     "Message.isSet" should {
         "return false for any default instance" {
             ValidationIteration.getDefaultInstance().isSet() shouldBe false
@@ -43,11 +41,8 @@ class DataExtensionsTest : WordSpec({
         }
     }
     "Timestamp.isValid" should {
-        "return false for a default instance" {
-            Timestamp.getDefaultInstance().isValid() shouldBe false
-        }
-        "return true for any UTC date other than the epoch" {
-            forAll(Arb.localDateTime(minLocalDateTime = LocalDateTime.of(1970, 1, 1, 0, 1))) { randomLocalDateTime ->
+        "return true for any UTC date" {
+            forAll(Arb.localDateTime()) { randomLocalDateTime ->
                 randomLocalDateTime.atOffset(ZoneOffset.UTC).toProtoTimestamp().isValid()
             }
         }
@@ -106,16 +101,8 @@ class DataExtensionsTest : WordSpec({
         }
     }
     "Money.isValid" should {
-        "return false for a default instance" {
-            FigureTechMoney.getDefaultInstance().isValid() shouldBe false
-        }
-        "return true for any number other than zero" {
-            forAll(Arb.double(max = -0.1)) { randomDouble ->
-                FigureTechMoney.newBuilder().apply {
-                    amount = randomDouble
-                }.build().isValid()
-            }
-            forAll(Arb.double(min = 0.1)) { randomDouble ->
+        "return true for any double" {
+            forAll(Arb.double()) { randomDouble ->
                 FigureTechMoney.newBuilder().apply {
                     amount = randomDouble
                 }.build().isValid()


### PR DESCRIPTION
### Changes
- Add files generated from contract bootstrapping to `.gitignore` and exclude them from the linter input
- Update references to `ktlintCheck` to clarify usage for returning linting errors versus generating test reports
- Move exceptions to dedicated file still under the same `utility` package
- Add double quotes to violation exception message to try to reduce potential confusion from a message containing non-alphanumeric characters and multiple violations
- Add `isNotSet` function for better code readability
- Remove value validation from money and timestamp validation extensions
  - It doesn't make sense to universally discard values of $0.00 or the epoch, as they could be valid in certain contexts