### PR TITLE
Update record nullabilities, fill out logic for remaining contracts, & add more tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ indent_size=4
 insert_final_newline=true
 # possible values: number (e.g. 120) (package name, imports & comments are ignored), "off"
 # it's automatically set to 100 on `ktlint --android ...` (per Android Kotlin Style Guide)
-max_line_length=145
+max_line_length=150
 [contract/**/contracts/*.{kt, kts}]
 # Rules disabled to allow for easier readability of certain contract code
 disabled_rules=wrapping,no-multi-spaces

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -43,13 +43,13 @@ data class LoanPackage(
     /** The servicing rights to the loan. Defaults to the lender. */
     @Record(LoanScopeFacts.servicingRights) var servicingRights: ServicingRights,
     /** A list of metadata for documents, including their URIs in an encrypted object store. */
-    @Record(LoanScopeFacts.documents) var documents: LoanDocuments? = null,
+    @Record(LoanScopeFacts.documents) var documents: LoanDocuments,
     /** Servicing data for the loan, including a list of metadata on loan states. */
-    @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData? = null,
+    @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData,
     /** A list of third-party validation iterations. */
-    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation? = null,
+    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation,
     /** The eNote for the loan. */
-    @Record(LoanScopeFacts.eNote) var eNote: ENote? = null
+    @Record(LoanScopeFacts.eNote) var eNote: ENote,
 )
 
 /**

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -33,7 +33,7 @@ open class AppendLoanStatesContract(
                     state.uri.isNotBlank()          orError "Invalid accrued interest",
                     state.checksum.isValid()        orError "Invalid checksum"
                 )
-                if (existingServicingData.loanStateList.none { it.effectiveTime == state.effectiveTime }) {
+                if (existingServicingData.loanStateList.none { it.effectiveTime == state.effectiveTime }) { // TODO: Improve check for duplicates
                     updatedServicingData.addLoanState(state)
                 }
             }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -9,17 +9,39 @@ import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
+import io.provenance.scope.loan.utility.isValid
+import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta1.ValidationIteration
 import tech.figure.validation.v1beta1.ValidationRequest
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Add/Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationRequestContract(
-    @Record(LoanScopeFacts.loanValidations) val existingResults: LoanValidation,
+    @Record(LoanScopeFacts.loanValidations) val validationRecord: LoanValidation,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Add/Change to VALIDATOR?
     @Record(LoanScopeFacts.loanValidations)
-    open fun recordLoanValidationRequest(@Input(LoanScopeInputs.validationRequest) newRequest: ValidationRequest) {
+    open fun recordLoanValidationRequest(@Input(LoanScopeInputs.validationRequest) submission: ValidationRequest): LoanValidation {
+        validateRequirements(VALID_INPUT,
+            submission.requestId.isValid()        orError "Request ID is missing",
+            submission.effectiveTime.isValid()    orError "Request timestamp is missing",
+            submission.snapshotUri.isNotBlank()   orError "Loan snapshot URI is missing",
+            submission.validatorName.isNotBlank() orError "Validator name is missing",
+            submission.requesterName.isNotBlank() orError "Requester name is missing",
+            validationRecord.iterationList.none { iteration ->
+                iteration.request.requestId == submission.requestId
+            } orError "A validation iteration with the same request ID already exists",
+        )
+        return validationRecord.toBuilder().also { recordBuilder ->
+            recordBuilder.addIteration(
+                ValidationIteration.newBuilder().also { iterationBuilder ->
+                    iterationBuilder.request = submission
+                }.build()
+            )
+        }.build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -11,6 +11,7 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -19,14 +20,14 @@ import tech.figure.util.v1beta1.DocumentMetadata
 @Participants(roles = [PartyType.OWNER]) // TODO: Change to controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteContract(
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote?,
+    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
     open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: DocumentMetadata): ENote {
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
-            (existingENote !== null) orError "Cannot create eNote using this contract",
+            existingENote.isSet() orError "Cannot create eNote using this contract",
         )
         validateRequirements(ContractRequirementType.VALID_INPUT,
             newENote.id.isValid()              orError "ENote missing ID",
@@ -35,6 +36,6 @@ open class UpdateENoteContract(
             newENote.documentType.isNotBlank() orError "ENote missing document type",
             newENote.checksum.isValid()        orError "ENote missing checksum",
         )
-        return existingENote!!.toBuilder().setENote(newENote).build()
+        return existingENote.toBuilder().setENote(newENote).build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
@@ -12,6 +12,7 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
@@ -19,19 +20,19 @@ import io.provenance.scope.loan.utility.validateRequirements
 @Participants([PartyType.OWNER/*, PartyType.CONTROLLER*/]) // TODO: Add controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteControllerContract(
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote?, // TODO: Confirm if this should be nullable and adjust code below accordingly
+    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER/*PartyType.CONTROLLER*/) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
     open fun updateENoteController(@Input(LoanScopeInputs.eNoteControllerUpdate) newController: Controller): ENote {
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
-            (existingENote !== null) orError "Cannot create eNote using this contract",
+            existingENote.isSet() orError "Cannot create eNote using this contract",
         )
         validateRequirements(ContractRequirementType.VALID_INPUT,
             newController.controllerUuid.isValid()    orError "Controller UUID is missing",
             newController.controllerName.isNotBlank() orError "Controller Name is missing",
         )
-        return existingENote!!.toBuilder().setController(newController).build()
+        return existingENote.toBuilder().setController(newController).build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
@@ -1,0 +1,16 @@
+package io.provenance.scope.loan.utility
+
+import com.google.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.Any as ProtobufAny
+import tech.figure.loan.v1beta1.Loan as FigureTechLoan
+
+internal inline fun <reified T : com.google.protobuf.Message> ProtobufAny.tryUnpackingAs(): T =
+    T::class.java.let { clazz ->
+        try {
+            unpack(clazz)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw UnexpectedContractStateException("Could not unpack as $clazz", exception)
+        }
+    }
+
+internal fun ProtobufAny.toLoan() = tryUnpackingAs<FigureTechLoan>()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -4,20 +4,33 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainIgnoringCase
 import io.provenance.scope.loan.test.Constructors.contractWithEmptyExistingValidationRecord
 import io.provenance.scope.loan.test.Constructors.contractWithSingleValidationIteration
 import io.provenance.scope.loan.test.Constructors.randomProtoUuid
 import io.provenance.scope.loan.test.Constructors.validResultSubmission
 import io.provenance.scope.loan.utility.ContractViolationException
+import io.provenance.scope.loan.utility.IllegalContractStateException
 import tech.figure.validation.v1beta1.ValidationResponse
 
 class RecordLoanValidationResultsUnitTest : WordSpec({
     "recordLoanValidationResults" When {
+        "executed without a validation request existing in the scope" should {
+            "throw an appropriate exception" {
+                shouldThrow<IllegalContractStateException> {
+                    contractWithEmptyExistingValidationRecord.apply {
+                        recordLoanValidationResults(validResultSubmission(randomProtoUuid))
+                    }
+                }.let { exception ->
+                    exception.message shouldContainIgnoringCase "validation iteration must exist"
+                }
+            }
+        }
         "given an invalid input" should {
             "throw an appropriate exception" {
                 ValidationResponse.getDefaultInstance().let { emptyResultSubmission ->
                     shouldThrow<ContractViolationException> {
-                        contractWithEmptyExistingValidationRecord.apply {
+                        contractWithSingleValidationIteration(randomProtoUuid).apply {
                             recordLoanValidationResults(emptyResultSubmission)
                         }
                     }.let { exception ->
@@ -26,12 +39,20 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
                 }
             }
         }
-        "given a valid input" xshould { // TODO: Enable once validResultSubmission is implemented
+        "given a valid input" should {
             "not throw an exception" {
                 shouldNotThrow<ContractViolationException> {
                     randomProtoUuid.let { iterationRequestId ->
-                        contractWithSingleValidationIteration(iterationRequestId).apply {
-                            recordLoanValidationResults(validResultSubmission(iterationRequestId))
+                        contractWithSingleValidationIteration(
+                            requestID = iterationRequestId,
+                            validatorName = "My Favorite Provider",
+                        ).apply {
+                            recordLoanValidationResults(
+                                validResultSubmission(
+                                    iterationRequestID = iterationRequestId,
+                                    resultSetProvider = "My Favorite Provider",
+                                )
+                            )
                         }
                     }
                 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -3,23 +3,29 @@ package io.provenance.scope.loan.test
 import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
 import io.provenance.scope.util.toProtoTimestamp
 import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta1.ValidationItem
 import tech.figure.validation.v1beta1.ValidationIteration
 import tech.figure.validation.v1beta1.ValidationRequest
 import tech.figure.validation.v1beta1.ValidationResponse
+import tech.figure.validation.v1beta1.ValidationResults
 import java.time.OffsetDateTime
+import java.util.UUID as JavaUUID
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 object Constructors {
     val randomProtoUuid: FigureTechUUID
         get() = FigureTechUUID.newBuilder().apply {
-            value = java.util.UUID.randomUUID().toString()
+            value = JavaUUID.randomUUID().toString()
         }.build()
 
     val contractWithEmptyExistingValidationRecord: RecordLoanValidationResultsContract
         get() = RecordLoanValidationResultsContract(
             LoanValidation.getDefaultInstance()
         )
-    fun contractWithSingleValidationIteration(requestID: FigureTechUUID) = RecordLoanValidationResultsContract(
+    fun contractWithSingleValidationIteration(
+        requestID: FigureTechUUID,
+        validatorName: String = "anotherRandomProviderName",
+    ) = RecordLoanValidationResultsContract(
         LoanValidation.newBuilder().also { validationRecordBuilder ->
             validationRecordBuilder.clearIteration()
             validationRecordBuilder.addIteration(
@@ -28,13 +34,27 @@ object Constructors {
                         requestBuilder.requestId = requestID
                         requestBuilder.ruleSetId = randomProtoUuid
                         requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
+                        requestBuilder.validatorName = validatorName
                     }.build()
                 }.build()
             )
         }.build()
     )
-    fun validResultSubmission(iterationRequestID: FigureTechUUID) = ValidationResponse.newBuilder().apply {
-        requestId = iterationRequestID
-        // TODO: Set remaining fields
+    fun validResultSubmission(
+        iterationRequestID: FigureTechUUID = randomProtoUuid,
+        resultSetID: FigureTechUUID = randomProtoUuid,
+        resultSetProvider: String = "arbitraryProviderName",
+    ): ValidationResponse = ValidationResponse.newBuilder().also { responseBuilder ->
+        responseBuilder.requestId = iterationRequestID
+        responseBuilder.results = ValidationResults.newBuilder().also { resultsBuilder ->
+            resultsBuilder.resultSetUuid = resultSetID
+            resultsBuilder.resultSetProvider = resultSetProvider
+            resultsBuilder.resultSetEffectiveTime = OffsetDateTime.now().toProtoTimestamp()
+            resultsBuilder.addValidationItems(
+                ValidationItem.newBuilder().also { validationItemBuilder ->
+                    validationItemBuilder.description = "Yep stuff passed I guess"
+                }.build()
+            )
+        }.build()
     }.build()
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -1,8 +1,11 @@
 package io.provenance.scope.loan.test
 
+import com.google.protobuf.InvalidProtocolBufferException
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
@@ -13,24 +16,37 @@ import io.provenance.scope.loan.utility.ContractEnforcement
 import io.provenance.scope.loan.utility.ContractViolation
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.ContractViolationMap
+import io.provenance.scope.loan.utility.UnexpectedContractStateException
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 
 /**
  * Generators of [Arb]itrary instances.
+ * Values denoted as "anyFoo" should return a valid _or_ invalid instance of Foo.
  */
 internal object LoanPackageArbs {
     /* Contract requirements */
-    val contractViolation: Arb<ContractViolation> = Arb.string()
-    val contractEnforcement: Arb<ContractEnforcement> = Arb.bind(
+    val anyContractViolation: Arb<ContractViolation> = Arb.string()
+    val anyContractEnforcement: Arb<ContractEnforcement> = Arb.bind(
         Arb.boolean(),
         Arb.string(),
     ) { requirement, violationReport ->
         ContractEnforcement(requirement, violationReport)
     }
-    val contractViolationMapArb: Arb<ContractViolationMap> = Arb.bind(
-        Arb.list(contractViolation),
+    val anyContractViolationMap: Arb<ContractViolationMap> = Arb.bind(
+        Arb.list(anyContractViolation),
         Arb.list(Arb.uInt()),
     ) { violationList, countList ->
         violationList.zip(countList).toMap().toMutableMap()
+    }
+    /* Figure Tech Protobufs */
+    val anyChecksum: Arb<FigureTechChecksum> = Arb.bind(
+        Arb.string(),
+        Arb.string(),
+    ) { checksumValue, algorithmType ->
+        FigureTechChecksum.newBuilder().apply {
+            checksum = checksumValue
+            algorithm = algorithmType
+        }.build()
     }
 }
 
@@ -62,4 +78,9 @@ internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolati
  */
 internal infix fun ContractViolationException.shouldHaveViolationCount(violationCount: UInt) = apply {
     this should throwViolationCount(violationCount)
+}
+
+internal infix fun UnexpectedContractStateException.shouldBeParseFailureFor(classifier: String) = apply {
+    this.cause should beInstanceOf<InvalidProtocolBufferException>()
+    this.message shouldBe "Could not unpack as class $classifier"
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsTest.kt
@@ -43,7 +43,7 @@ class ContractRequirementsTest : WordSpec({
                 }
             }
             "return state violations only for failed conditions" {
-                checkAll(Arb.list(LoanPackageArbs.contractEnforcement)) { enforcementList ->
+                checkAll(Arb.list(LoanPackageArbs.anyContractEnforcement)) { enforcementList ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<IllegalContractStateException> {
@@ -59,7 +59,7 @@ class ContractRequirementsTest : WordSpec({
                 }
             }
             "return input violations only for failed conditions" {
-                checkAll(Arb.list(LoanPackageArbs.contractEnforcement)) { enforcementList ->
+                checkAll(Arb.list(LoanPackageArbs.anyContractEnforcement)) { enforcementList ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<ContractViolationException> {
@@ -78,8 +78,8 @@ class ContractRequirementsTest : WordSpec({
         "invoked with a function body" should {
             "return state violations only for failed conditions" {
                 checkAll(
-                    Arb.list(LoanPackageArbs.contractEnforcement),
-                    Arb.list(LoanPackageArbs.contractEnforcement),
+                    Arb.list(LoanPackageArbs.anyContractEnforcement),
+                    Arb.list(LoanPackageArbs.anyContractEnforcement),
                 ) { enforcementListA, enforcementListB ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
                     if (expectedOverallViolationCount > 0U) {
@@ -109,8 +109,8 @@ class ContractRequirementsTest : WordSpec({
             }
             "return input violations only for failed conditions" {
                 checkAll(
-                    Arb.list(LoanPackageArbs.contractEnforcement),
-                    Arb.list(LoanPackageArbs.contractEnforcement),
+                    Arb.list(LoanPackageArbs.anyContractEnforcement),
+                    Arb.list(LoanPackageArbs.anyContractEnforcement),
                 ) { enforcementListA, enforcementListB ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
                     if (expectedOverallViolationCount > 0U) {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsTest.kt
@@ -1,0 +1,59 @@
+package io.provenance.scope.loan.utility
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.LoanPackageArbs
+import io.provenance.scope.loan.test.shouldBeParseFailureFor
+import tech.figure.proto.util.toProtoAny
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
+
+class DataConversionExtensionsTest : WordSpec({
+    "tryUnpackingAs" should {
+        "successfully unpack a packed protobuf as the same type that was packed" {
+            checkAll(LoanPackageArbs.anyChecksum) { randomChecksum ->
+                shouldNotThrow<UnexpectedContractStateException> {
+                    randomChecksum.toProtoAny().tryUnpackingAs<FigureTechChecksum>() shouldBe randomChecksum
+                }
+            }
+        }
+        "fail to unpack a packed protobuf as a type with inherently different fields" {
+            checkAll(LoanPackageArbs.anyChecksum) { randomChecksum ->
+                shouldThrow<UnexpectedContractStateException> {
+                    randomChecksum.toProtoAny().tryUnpackingAs<FigureTechUUID>()
+                }.let { exception ->
+                    exception shouldBeParseFailureFor "tech.figure.util.v1beta1.UUID"
+                }
+            }
+        }
+    }
+    "toLoan" should {
+        "throw an exception for unpacking when called on a non-nullable inapplicable protobuf" {
+            checkAll(Arb.string(), Arb.string(minSize = 1)) { randomString, randomNonEmptyString ->
+                FigureTechChecksum.newBuilder().apply {
+                    checksum = randomString
+                    algorithm = randomNonEmptyString
+                }.build().let { randomChecksum ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        randomChecksum?.toProtoAny()?.toLoan()
+                    }.let { exception ->
+                        exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
+                    }
+                    IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
+                        shouldThrow<IllegalArgumentException> { // Sanity check that parsing is only attempted when intended by code
+                            randomChecksum.takeIf { it.algorithm.isNullOrBlank() }?.toProtoAny()?.toLoan()
+                                ?: throw callerException
+                        }.let { thrownException ->
+                            thrownException shouldBe callerException
+                        }
+                    }
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
### Context
Testing contract execution using https://github.com/provenance-io/p8e-cee-api/ revealed that using nullable types for records would cause `java.lang.ClassNotFoundException`s there [when trying to find the class type through reflection](https://github.com/provenance-io/p8e-cee-api/blob/1ca3332dd47568001ea18c299e03525dee3439f7/service/src/main/kotlin/io/provenance/onboarding/domain/usecase/cee/execute/ExecuteContract.kt#L80). We can avoid said exception and potential confusion from null or default values not translating into actual contract behavior by recognizing that contracts can check if a record is null _or_ a default instance.
### Changes
- Bump linter's maximum line length up to 150 😅 
- Remove nullability and default values from all loan scope records
  - "is not null" checks replaced with `isSet()` calls
- Improve efficiency and logic of checksum validation in `AppendLoanDocContract`
- Uncomment implementation of `recordAsset` in `RecordLoanContract`
- Fill out `RecordLoanValidationRequestContract`
- Fix mistakes in `RecordLoanValidationResultsContract`
- Add tests for protobuf type conversions
- Complete test case for recording valid loan validation results
- Tweak some `LoanPackageArbs` value names
- Update TODOs as necessary
- Adjust some violation message wordings
### Notes
- Hoping to add just tests for existing untested code in the next PR
- Is "nullabilities" a word?