### PR TITLE
DRY input validation calls & continue adding tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,8 +7,13 @@ insert_final_newline=true
 # possible values: number (e.g. 120) (package name, imports & comments are ignored), "off"
 # it's automatically set to 100 on `ktlint --android ...` (per Android Kotlin Style Guide)
 max_line_length=150
-[contract/**/contracts/*.{kt, kts}]
-# Rules disabled to allow for easier readability of certain contract code
-disabled_rules=wrapping,no-multi-spaces
+
+### buildSrc
 [buildSrc/**.{kt, kts}]
 disabled_rules=filename
+
+### Contract input validation - to improve readability
+[contract/**/contracts/*.kt]
+disabled_rules=wrapping,no-multi-spaces
+[contract/**/utility/LoanContractValidations.kt]
+disabled_rules=wrapping,no-multi-spaces

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ val ktlintFormat by tasks.creating(JavaExec::class) {
     description = "Fix Kotlin code style deviations."
     classpath = ktlint
     mainClass.set("com.pinterest.ktlint.Main")
-    args = listOf("-F", "*/src/**/*.kt")
+    args = listOf("-F", "*/src/**/*.kt") + ktlintExcludeSyntax(lintingExclusions)
 }
 
 /** Project Setup & Releasing */

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocContract.kt
@@ -9,8 +9,8 @@ import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
+import io.provenance.scope.loan.utility.documentValidation
 import io.provenance.scope.loan.utility.isValid
-import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.loan.v1beta1.LoanDocuments
 
@@ -33,13 +33,7 @@ open class AppendLoanDocContract(
                 }
             }
             newDocs.documentList.forEach { doc ->
-                requireThat(
-                    doc.id.isValid()              orError "Document missing ID",
-                    doc.uri.isNotBlank()          orError "Document with ID ${doc.id} is missing URI",
-                    doc.contentType.isNotBlank()  orError "Document with ID ${doc.id} is missing content type",
-                    doc.documentType.isNotBlank() orError "Document with ID ${doc.id} is missing document type",
-                    doc.checksum.isValid()        orError "Document with ID ${doc.id} is missing checksum",
-                )
+                documentValidation(doc)
                 doc.checksum.checksum?.let { newDocChecksum ->
                     if (existingDocChecksums[newDocChecksum] != true) { // TODO: Confirm that we want to silently ignore duplicates
                         newDocList.addDocument(doc)

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -15,7 +15,7 @@ import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 
-@Participants(roles = [PartyType.OWNER])
+@Participants(roles = [PartyType.OWNER]) // TODO: Eventually update to servicer
 @ScopeSpecification(["tech.figure.loan"])
 open class AppendLoanStatesContract(
     @Record(LoanScopeFacts.servicingData) val existingServicingData: ServicingData,
@@ -27,13 +27,14 @@ open class AppendLoanStatesContract(
         val updatedServicingData = ServicingData.newBuilder().mergeFrom(existingServicingData)
         validateRequirements(VALID_INPUT) {
             for (state in newLoanStates) {
+                // TODO: Improve check for duplicates (ID, effectiveTime, & checksum) & confirm if/which we want to silently ignore or raise violation
                 requireThat(
                     state.id.isValid()              orError "Invalid id",
                     state.effectiveTime.isValid()   orError "Invalid effective time",
                     state.uri.isNotBlank()          orError "Invalid accrued interest",
                     state.checksum.isValid()        orError "Invalid checksum"
                 )
-                if (existingServicingData.loanStateList.none { it.effectiveTime == state.effectiveTime }) { // TODO: Improve check for duplicates
+                if (existingServicingData.loanStateList.none { it.effectiveTime == state.effectiveTime }) {
                     updatedServicingData.addLoanState(state)
                 }
             }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -10,28 +10,18 @@ import io.provenance.scope.contract.proto.Specifications
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
-import io.provenance.scope.loan.utility.isValid
-import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.eNoteValidation
 import io.provenance.scope.loan.utility.validateRequirements
 
 @Participants(roles = [Specifications.PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordENoteContract : P8eContract() {
-
+    // TODO: Add function modifying servicing data record with servicing data as input
     @Function(invokedBy = Specifications.PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote) = eNote.also {
-        validateRequirements(VALID_INPUT,
-            // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
-            eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
-            eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
-            eNote.eNote.id.isValid()                     orError "ENote missing ID",
-            eNote.eNote.uri.isNotBlank()                 orError "ENote missing uri",
-            eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
-            eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
-            eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
-            eNote.signedDate.isValid()                   orError "ENote missing signed date",
-            eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
-        )
+        validateRequirements(VALID_INPUT) {
+            eNoteValidation(eNote)
+        }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -11,9 +11,12 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.UnexpectedContractStateException
+import io.provenance.scope.loan.utility.documentListInputValidation
+import io.provenance.scope.loan.utility.eNoteValidation
 import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.servicingRightsInputValidation
 import io.provenance.scope.loan.utility.toLoan
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.asset.v1beta1.Asset
@@ -62,19 +65,20 @@ open class RecordLoanContract(
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingRights)
-    open fun recordServicingRights(@Input(LoanScopeFacts.servicingRights) servicingRights: ServicingRights) = servicingRights
+    open fun recordServicingRights(@Input(LoanScopeFacts.servicingRights) servicingRights: ServicingRights) =
+        servicingRights.also(servicingRightsInputValidation)
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.documents)
-    open fun recordDocuments(@Input(LoanScopeFacts.documents) documents: LoanDocuments) = documents
+    open fun recordDocuments(@Input(LoanScopeFacts.documents) documents: LoanDocuments) = documents.also(documentListInputValidation)
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingData)
-    open fun recordLoanStates(@Input(LoanScopeFacts.servicingData) servicingData: ServicingData) = servicingData
+    open fun recordServicingData(@Input(LoanScopeFacts.servicingData) servicingData: ServicingData) = servicingData // TODO: Validate input
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.loanValidations)
-    open fun recordValidationResults(@Input(LoanScopeFacts.loanValidations) loanValidations: LoanValidation) = loanValidations
+    open fun recordValidationData(@Input(LoanScopeFacts.loanValidations) loanValidations: LoanValidation) = loanValidations // TODO: Validate input
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
@@ -85,18 +89,7 @@ open class RecordLoanContract(
                     "ENote with a different checksum already exists on chain for the specified scope; ENote modifications are not allowed!"
                 )
             }
-            // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
-            requireThat(
-                eNote.controller.controllerUuid.isValid()    orError "ENote missing controller UUID",
-                eNote.controller.controllerName.isNotBlank() orError "ENote missing controller Name",
-                eNote.eNote.id.isValid()                     orError "ENote missing ID",
-                eNote.eNote.uri.isNotBlank()                 orError "ENote missing URI",
-                eNote.eNote.contentType.isNotBlank()         orError "ENote missing content type",
-                eNote.eNote.documentType.isNotBlank()        orError "ENote missing document type",
-                eNote.eNote.checksum.isValid()               orError "ENote missing checksum",
-                eNote.signedDate.isValid()                   orError "ENote missing signed date",
-                eNote.vaultName.isNotBlank()                 orError "ENote missing vault name",
-            )
+            eNoteValidation(eNote)
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -11,8 +11,8 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.eNoteDocumentValidation
 import io.provenance.scope.loan.utility.isSet
-import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.util.v1beta1.DocumentMetadata
@@ -29,13 +29,9 @@ open class UpdateENoteContract(
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
             existingENote.isSet() orError "Cannot create eNote using this contract",
         )
-        validateRequirements(ContractRequirementType.VALID_INPUT,
-            newENote.id.isValid()              orError "ENote missing ID",
-            newENote.uri.isNotBlank()          orError "ENote missing uri",
-            newENote.contentType.isNotBlank()  orError "ENote missing content type",
-            newENote.documentType.isNotBlank() orError "ENote missing document type",
-            newENote.checksum.isValid()        orError "ENote missing checksum",
-        )
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            eNoteDocumentValidation(newENote)
+        }
         return existingENote.toBuilder().setENote(newENote).build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
@@ -12,8 +12,8 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.eNoteControllerValidation
 import io.provenance.scope.loan.utility.isSet
-import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 
@@ -29,10 +29,9 @@ open class UpdateENoteControllerContract(
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
             existingENote.isSet() orError "Cannot create eNote using this contract",
         )
-        validateRequirements(ContractRequirementType.VALID_INPUT,
-            newController.controllerUuid.isValid()    orError "Controller UUID is missing",
-            newController.controllerName.isNotBlank() orError "Controller Name is missing",
-        )
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            eNoteControllerValidation(newController)
+        }
         return existingENote.toBuilder().setController(newController).build()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateServicingRightsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateServicingRightsContract.kt
@@ -8,10 +8,7 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
-import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
-import io.provenance.scope.loan.utility.isValid
-import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.validateRequirements
+import io.provenance.scope.loan.utility.servicingRightsInputValidation
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 
 @Participants(roles = [PartyType.OWNER])
@@ -20,10 +17,6 @@ open class UpdateServicingRightsContract : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingRights)
-    open fun updateServicingRights(@Input(LoanScopeFacts.servicingRights) servicingRights: ServicingRights) = servicingRights.also {
-        validateRequirements(VALID_INPUT,
-            servicingRights.servicerId.isValid()      orError "Missing servicer UUID",
-            servicingRights.servicerName.isNotBlank() orError "Missing servicer name",
-        )
-    }
+    open fun updateServicingRights(@Input(LoanScopeFacts.servicingRights) servicingRights: ServicingRights) =
+        servicingRights.also(servicingRightsInputValidation)
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
@@ -1,0 +1,64 @@
+package io.provenance.scope.loan.utility
+
+import io.dartinc.registry.v1beta1.ENote
+import tech.figure.loan.v1beta1.LoanDocuments
+import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
+import tech.figure.util.v1beta1.DocumentMetadata
+import io.dartinc.registry.v1beta1.Controller as ENoteController
+
+internal val documentListInputValidation: (LoanDocuments) -> Unit = { documents ->
+    validateRequirements(ContractRequirementType.VALID_INPUT) {
+        documents.documentList.forEach { document ->
+            documentValidation(document)
+        }
+    }
+}
+
+internal val documentValidation: ContractEnforcementContext.(DocumentMetadata) -> Unit = { document ->
+    val documentIdSnippet = if (document.id.isSet()) {
+        " with ID ${document.id}"
+    } else {
+        ""
+    }
+    requireThat(
+        document.id.isValid()              orError "Document missing ID",
+        document.uri.isNotBlank()          orError "Document$documentIdSnippet is missing URI",
+        document.contentType.isNotBlank()  orError "Document$documentIdSnippet is missing content type",
+        document.documentType.isNotBlank() orError "Document$documentIdSnippet is missing document type",
+        document.checksum.isValid()        orError "Document$documentIdSnippet is missing checksum",
+    )
+}
+
+internal val eNoteControllerValidation: ContractEnforcementContext.(ENoteController) -> Unit = { controller ->
+    requireThat(
+        controller.controllerUuid.isValid()    orError "Missing controller UUID",
+        controller.controllerName.isNotBlank() orError "Missing controller name",
+    )
+}
+
+internal val eNoteDocumentValidation: ContractEnforcementContext.(DocumentMetadata) -> Unit = { document ->
+    requireThat(
+        document.id.isValid()              orError "ENote missing ID",
+        document.uri.isNotBlank()          orError "ENote missing URI",
+        document.contentType.isNotBlank()  orError "ENote missing content type",
+        document.documentType.isNotBlank() orError "ENote missing document type",
+        document.checksum.isValid()        orError "ENote missing checksum",
+    )
+}
+
+internal val eNoteValidation: ContractEnforcementContext.(ENote) -> Unit = { eNote ->
+    // TODO: Decide which fields should only be required if DART is listed as mortgagee of record/active custodian
+    eNoteControllerValidation(eNote.controller)
+    eNoteDocumentValidation(eNote.eNote)
+    requireThat(
+        eNote.signedDate.isValid()   orError "ENote missing signed date",
+        eNote.vaultName.isNotBlank() orError "ENote missing vault name",
+    )
+}
+
+internal val servicingRightsInputValidation: (ServicingRights) -> Unit = { servicingRights ->
+    validateRequirements(ContractRequirementType.VALID_INPUT,
+        servicingRights.servicerId.isValid()      orError "Missing servicer UUID",
+        servicingRights.servicerName.isNotBlank() orError "Missing servicer name",
+    )
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
@@ -1,0 +1,165 @@
+package io.provenance.scope.loan.contracts
+
+import io.dartinc.registry.v1beta1.ENote
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.string.shouldContainIgnoringCase
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import io.provenance.scope.loan.test.Constructors.recordContractWithEmptyScope
+import io.provenance.scope.loan.test.LoanPackageArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.LoanPackageArbs.anyUuid
+import io.provenance.scope.loan.test.shouldBeParseFailureFor
+import io.provenance.scope.loan.utility.ContractViolationException
+import io.provenance.scope.loan.utility.UnexpectedContractStateException
+import tech.figure.asset.v1beta1.Asset
+import tech.figure.loan.v1beta1.Loan
+import tech.figure.proto.util.toProtoAny
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
+
+class RecordLoanContractUnitTest : WordSpec({
+    "recordAsset" When {
+        "given an empty input" should {
+            "throw an appropriate exception" {
+                Asset.getDefaultInstance().let { emptyAssetWithoutLoan ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        recordContractWithEmptyScope.recordAsset(emptyAssetWithoutLoan)
+                    }.let { exception ->
+                        exception.message shouldContainIgnoringCase "No key \"loan\" was found"
+                    }
+                }
+            }
+        }
+        "given an input with a loan value of an incorrect type" should {
+            "throw an appropriate exception" {
+                Asset.newBuilder().also { assetBuilder ->
+                    assetBuilder.putKv("loan", FigureTechUUID.getDefaultInstance().toProtoAny())
+                }.build().let { assetWithBadLoanType ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        recordContractWithEmptyScope.recordAsset(assetWithBadLoanType)
+                    }.let { exception ->
+                        exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
+                    }
+                }
+            }
+        }
+        "given an input with invalid changes to existing data" should {
+            "throw an appropriate exception" {
+                val existingAsset = Asset.newBuilder().apply {
+                    id = randomProtoUuid // To mark the existing asset as being set
+                    putKv(
+                        "loan",
+                        Loan.newBuilder().also { loanBuilder ->
+                            loanBuilder.id = randomProtoUuid
+                        }.build().toProtoAny()
+                    )
+                }.build()
+                val newAsset = Asset.newBuilder().also { assetBuilder ->
+                    assetBuilder.putKv(
+                        "loan",
+                        Loan.newBuilder().also { loanBuilder ->
+                            loanBuilder.id = randomProtoUuid
+                        }.build().toProtoAny()
+                    )
+                }.build()
+                shouldThrow<ContractViolationException> { // Assuming no UUID collision...
+                    RecordLoanContract(
+                        existingAsset = existingAsset,
+                        existingENote = ENote.getDefaultInstance(),
+                    ).recordAsset(newAsset)
+                }.let { exception ->
+                    exception.message shouldContainIgnoringCase "Cannot change asset ID"
+                }
+            }
+        }
+        "given an valid input with no existing asset record on scope" should {
+            "not throw an exception" {
+                checkAll(anyUuid, anyUuid, anyNonEmptyString, anyNonEmptyString) { randomAssetId, randomLoanId, randomType, randomOriginatorName ->
+                    recordContractWithEmptyScope.recordAsset(
+                        Asset.newBuilder().apply {
+                            id = randomAssetId
+                            type = randomType
+                            putKv(
+                                "loan",
+                                Loan.newBuilder().also { loanBuilder ->
+                                    loanBuilder.id = randomLoanId
+                                    loanBuilder.originatorName = randomOriginatorName
+                                }.build().toProtoAny()
+                            )
+                        }.build()
+                    )
+                }
+            }
+        }
+        "given an valid input with an existing asset record on scope" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordServicingRights" When {
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordDocuments" When {
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordServicingData" When {
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordValidationData" When {
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordENote" When {
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input with no existing eNote record on scope" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+        "given an valid input with an existing eNote record on scope" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
@@ -1,0 +1,43 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.string.shouldContain
+import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import io.provenance.scope.loan.test.Constructors.requestContractWithEmptyExistingRecord
+import io.provenance.scope.loan.test.Constructors.validRequest
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.validation.v1beta1.ValidationRequest
+
+class RecordLoanValidationRequestUnitTest : WordSpec({
+    "recordLoanValidationRequest" When {
+        "given an invalid input" should {
+            "throw an appropriate exception" {
+                ValidationRequest.getDefaultInstance().let { emptyResultSubmission ->
+                    shouldThrow<ContractViolationException> {
+                        requestContractWithEmptyExistingRecord.apply {
+                            recordLoanValidationRequest(emptyResultSubmission)
+                        }
+                    }.let { exception ->
+                        exception.message shouldContain "Request ID is missing"
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
+            "not throw an exception" {
+                shouldNotThrow<ContractViolationException> {
+                    requestContractWithEmptyExistingRecord.apply {
+                        recordLoanValidationRequest(
+                            validRequest(
+                                requestID = randomProtoUuid,
+                                validatorName = "My Adequate Provider",
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -5,9 +5,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainIgnoringCase
-import io.provenance.scope.loan.test.Constructors.contractWithEmptyExistingValidationRecord
-import io.provenance.scope.loan.test.Constructors.contractWithSingleValidationIteration
 import io.provenance.scope.loan.test.Constructors.randomProtoUuid
+import io.provenance.scope.loan.test.Constructors.resultsContractWithEmptyExistingRecord
+import io.provenance.scope.loan.test.Constructors.resultsContractWithSingleRequest
 import io.provenance.scope.loan.test.Constructors.validResultSubmission
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.IllegalContractStateException
@@ -18,7 +18,7 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
         "executed without a validation request existing in the scope" should {
             "throw an appropriate exception" {
                 shouldThrow<IllegalContractStateException> {
-                    contractWithEmptyExistingValidationRecord.apply {
+                    resultsContractWithEmptyExistingRecord.apply {
                         recordLoanValidationResults(validResultSubmission(randomProtoUuid))
                     }
                 }.let { exception ->
@@ -26,11 +26,11 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
                 }
             }
         }
-        "given an invalid input" should {
+        "given an empty input" should {
             "throw an appropriate exception" {
                 ValidationResponse.getDefaultInstance().let { emptyResultSubmission ->
                     shouldThrow<ContractViolationException> {
-                        contractWithSingleValidationIteration(randomProtoUuid).apply {
+                        resultsContractWithSingleRequest(randomProtoUuid).apply {
                             recordLoanValidationResults(emptyResultSubmission)
                         }
                     }.let { exception ->
@@ -43,7 +43,7 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
             "not throw an exception" {
                 shouldNotThrow<ContractViolationException> {
                     randomProtoUuid.let { iterationRequestId ->
-                        contractWithSingleValidationIteration(
+                        resultsContractWithSingleRequest(
                             requestID = iterationRequestId,
                             validatorName = "My Favorite Provider",
                         ).apply {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -1,7 +1,11 @@
 package io.provenance.scope.loan.test
 
+import io.dartinc.registry.v1beta1.ENote
+import io.provenance.scope.loan.contracts.RecordLoanContract
+import io.provenance.scope.loan.contracts.RecordLoanValidationRequestContract
 import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
 import io.provenance.scope.util.toProtoTimestamp
+import tech.figure.asset.v1beta1.Asset
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationItem
 import tech.figure.validation.v1beta1.ValidationIteration
@@ -17,12 +21,33 @@ object Constructors {
         get() = FigureTechUUID.newBuilder().apply {
             value = JavaUUID.randomUUID().toString()
         }.build()
-
-    val contractWithEmptyExistingValidationRecord: RecordLoanValidationResultsContract
+    val recordContractWithEmptyScope: RecordLoanContract
+        get() = RecordLoanContract(
+            existingAsset = Asset.getDefaultInstance(),
+            existingENote = ENote.getDefaultInstance(),
+        )
+    val resultsContractWithEmptyExistingRecord: RecordLoanValidationResultsContract
         get() = RecordLoanValidationResultsContract(
             LoanValidation.getDefaultInstance()
         )
-    fun contractWithSingleValidationIteration(
+
+    val requestContractWithEmptyExistingRecord: RecordLoanValidationRequestContract
+        get() = RecordLoanValidationRequestContract(
+            LoanValidation.getDefaultInstance()
+        )
+    fun validRequest(
+        requestID: FigureTechUUID,
+        requesterName: String = "someArbitraryRequesterName",
+        validatorName: String = "yetAnotherRandomProviderName",
+    ): ValidationRequest = ValidationRequest.newBuilder().also { requestBuilder ->
+        requestBuilder.requestId = requestID
+        requestBuilder.ruleSetId = randomProtoUuid
+        requestBuilder.snapshotUri = randomProtoUuid.value
+        requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
+        requestBuilder.requesterName = requesterName
+        requestBuilder.validatorName = validatorName
+    }.build()
+    fun resultsContractWithSingleRequest(
         requestID: FigureTechUUID,
         validatorName: String = "anotherRandomProviderName",
     ) = RecordLoanValidationResultsContract(
@@ -30,12 +55,10 @@ object Constructors {
             validationRecordBuilder.clearIteration()
             validationRecordBuilder.addIteration(
                 ValidationIteration.newBuilder().also { iterationBuilder ->
-                    iterationBuilder.request = ValidationRequest.newBuilder().also { requestBuilder ->
-                        requestBuilder.requestId = requestID
-                        requestBuilder.ruleSetId = randomProtoUuid
-                        requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
-                        requestBuilder.validatorName = validatorName
-                    }.build()
+                    iterationBuilder.request = validRequest(
+                        requestID = requestID,
+                        validatorName = validatorName,
+                    )
                 }.build()
             )
         }.build()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -7,23 +7,29 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.UUIDVersion
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.uInt
+import io.kotest.property.arbitrary.uuid
 import io.provenance.scope.loan.utility.ContractEnforcement
 import io.provenance.scope.loan.utility.ContractViolation
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.ContractViolationMap
 import io.provenance.scope.loan.utility.UnexpectedContractStateException
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 /**
  * Generators of [Arb]itrary instances.
- * Values denoted as "anyFoo" should return a valid _or_ invalid instance of Foo.
  */
 internal object LoanPackageArbs {
+    /* Primitives */
+    val anyNonEmptyString: Arb<String> = Arb.string().filter { it.isNotBlank() }
     /* Contract requirements */
     val anyContractViolation: Arb<ContractViolation> = Arb.string()
     val anyContractEnforcement: Arb<ContractEnforcement> = Arb.bind(
@@ -46,6 +52,11 @@ internal object LoanPackageArbs {
         FigureTechChecksum.newBuilder().apply {
             checksum = checksumValue
             algorithm = algorithmType
+        }.build()
+    }
+    val anyUuid: Arb<FigureTechUUID> = Arb.uuid(UUIDVersion.V4).map { arbUuidV4 ->
+        FigureTechUUID.newBuilder().apply {
+            value = arbUuidV4.toString()
         }.build()
     }
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -15,7 +15,7 @@ import io.kotest.property.checkAll
 import io.provenance.scope.loan.test.LoanPackageArbs
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 
-class ContractRequirementsTest : WordSpec({
+class ContractRequirementsUnitTest : WordSpec({
     /* Helpers */
     fun getExpectedViolationCount(enforcements: List<ContractEnforcement>) =
         enforcements.fold(

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
@@ -13,7 +13,7 @@ import tech.figure.proto.util.toProtoAny
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
-class DataConversionExtensionsTest : WordSpec({
+class DataConversionExtensionsUnitTest : WordSpec({
     "tryUnpackingAs" should {
         "successfully unpack a packed protobuf as the same type that was packed" {
             checkAll(LoanPackageArbs.anyChecksum) { randomChecksum ->
@@ -34,10 +34,10 @@ class DataConversionExtensionsTest : WordSpec({
     }
     "toLoan" should {
         "throw an exception for unpacking when called on a non-nullable inapplicable protobuf" {
-            checkAll(Arb.string(), Arb.string(minSize = 1)) { randomString, randomNonEmptyString ->
+            checkAll(Arb.string(), Arb.string()) { randomChecksumString, randomAlgorithmString ->
                 FigureTechChecksum.newBuilder().apply {
-                    checksum = randomString
-                    algorithm = randomNonEmptyString
+                    checksum = randomChecksumString
+                    algorithm = randomAlgorithmString
                 }.build().let { randomChecksum ->
                     shouldThrow<UnexpectedContractStateException> {
                         randomChecksum?.toProtoAny()?.toLoan()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsUnitTest.kt
@@ -4,6 +4,7 @@ import com.google.protobuf.Any
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.UUIDVersion
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.localDate
 import io.kotest.property.arbitrary.localDateTime
@@ -21,7 +22,7 @@ import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.Money as FigureTechMoney
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
-class DataValidationExtensionsTest : WordSpec({
+class DataValidationExtensionsUnitTest : WordSpec({
     "Message.isSet" should {
         "return false for any default instance" {
             ValidationIteration.getDefaultInstance().isSet() shouldBe false
@@ -93,7 +94,7 @@ class DataValidationExtensionsTest : WordSpec({
             }
         }
         "return true for any valid instance" {
-            forAll(Arb.uuid()) { randomJavaUuidV4 ->
+            forAll(Arb.uuid(UUIDVersion.V4)) { randomJavaUuidV4 ->
                 FigureTechUUID.newBuilder().apply {
                     value = randomJavaUuidV4.toString()
                 }.build().isValid()


### PR DESCRIPTION
### Context
We have multiple contract functions that update the same record, and thus want to perform input validation of the same data types. To avoid redundancy, promote consistent rules, and keep the contract classes focused on showing how they extend the `io.provenance.scope.contract.spec.P8eContract` class, we can DRY these validation rules.
### Changes
- Centralize contract `@Input` validation logic in `io.provenance.scope.loan.utility.LoanContractViolations.kt`
  - As stated above, this DRYs contract code & allows logic as well as violation messages to be kept uniform
  - Mirrored the existing linting rule exception to also apply to this new file
- Add unit tests for `RecordLoanValidationRequest`
- Partially implement unit tests for `RecordLoanContract`
- Update unit test class names to clarify that they are meant to include only unit testing
- Adjust some test helper value names
- Tweak a few other minor test details
- Add `.gitignore` exclusions to `ktlintFormat` task
- Update more TODOs in light of https://github.com/provenance-io/p8e-scope-sdk/pull/55 and https://github.com/provenance-io/p8e-scope-sdk/pull/56
### Proceeding Work
- Add remaining unit tests for all contract functions
- Update contract class constructors and annotations after aforementioned `p8e-scope-sdk` PRs have been merged and then tested in `loan-package-contracts` locally