### PR TITLE
Implement usage of optional records for contract constructor values

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -14,7 +14,7 @@ object Versions {
     const val BouncyCastle = "1.70"
     object Plugins {
         const val NexusPublishing = "1.1.0"
-        const val P8ePublishing = "0.6.5"
+        const val P8ePublishing = "0.6.6"
         const val Protobuf = "0.8.18"
         const val SemVer = "0.3.13"
     }
@@ -24,7 +24,7 @@ object Versions {
         const val Protobuf = "3.20.1"
         const val SemVer = "1.1.2"
         object Provenance {
-            const val Scope = "0.5.1"
+            const val Scope = "0.6.0"
             const val MetadataAssetModel = "0.1.8"
         }
     }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -19,7 +19,7 @@ object Versions {
         const val SemVer = "0.3.13"
     }
     object Dependencies {
-        const val Grpc = "1.39.0"
+        const val Grpc = "1.45.0"
         const val ProtocGenValidate = "0.6.7"
         const val Protobuf = "3.20.1"
         const val SemVer = "1.1.2"

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -9,24 +9,23 @@ import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
-import io.provenance.scope.loan.utility.ContractRequirementType
-import io.provenance.scope.loan.utility.appendLoanStates
-import io.provenance.scope.loan.utility.validateRequirements
+import io.provenance.scope.loan.utility.updateServicingData
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Eventually update to servicer
 @ScopeSpecification(["tech.figure.loan"])
 open class AppendLoanStatesContract(
-    @Record(LoanScopeFacts.servicingData) val existingServicingData: ServicingData,
+    @Record(name = LoanScopeFacts.servicingData, optional = true) val existingServicingData: ServicingData?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingData)
     open fun appendLoanStates(@Input(LoanScopeInputs.newLoanStates) newLoanStates: Collection<LoanStateMetadata>): ServicingData =
-        ServicingData.newBuilder(existingServicingData).also { servicingDataBuilder ->
-            validateRequirements(ContractRequirementType.VALID_INPUT) {
-                appendLoanStates(servicingDataBuilder, newLoanStates)
-            }
-        }.build()
+        updateServicingData(
+            existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
+            newServicingData = ServicingData.newBuilder().also { incomingBuilder ->
+                incomingBuilder.addAllLoanState(newLoanStates)
+            }.build(),
+        )
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/InitializeLoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/InitializeLoanScope.kt
@@ -30,9 +30,7 @@ import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 
-/**
- * A contract designed to be a temporary workaround to pending support in `p8e-scope-sdk` for optional constructor record values.
- */
+// TODO: Delete this contract once optional records have been proven to work
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 class InitializeLoanScope : P8eContract() {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -16,7 +16,7 @@ import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordENoteContract(
-    @Record(LoanScopeFacts.servicingData) val existingServicingData: ServicingData, // TODO: Make optional?
+    @Record(name = LoanScopeFacts.servicingData, optional = true) val existingServicingData: ServicingData?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
@@ -27,7 +27,7 @@ open class RecordENoteContract(
     @Record(LoanScopeFacts.servicingData)
     open fun recordServicingData(@Input(LoanScopeFacts.servicingData) newServicingData: ServicingData): ServicingData =
         updateServicingData(
-            existingServicingData = existingServicingData,
+            existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
             newServicingData = newServicingData,
         )
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -20,7 +20,7 @@ import tech.figure.validation.v1beta1.ValidationRequest
 @Participants(roles = [PartyType.OWNER]) // TODO: Add/Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationRequestContract(
-    @Record(LoanScopeFacts.loanValidations) val validationRecord: LoanValidation,
+    @Record(name = LoanScopeFacts.loanValidations, optional = true) val validationRecord: LoanValidation?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Add/Change to VALIDATOR?
@@ -32,11 +32,11 @@ open class RecordLoanValidationRequestContract(
             submission.snapshotUri.isNotBlank()   orError "Request is missing loan snapshot URI",
             submission.validatorName.isNotBlank() orError "Request is missing validator name",
             submission.requesterName.isNotBlank() orError "Request is missing requester name",
-            validationRecord.iterationList.none { iteration ->
+            validationRecord?.iterationList?.none { iteration ->
                 iteration.request.requestId == submission.requestId
             } orError "A validation iteration with the same request ID already exists",
         )
-        return validationRecord.toBuilder().also { recordBuilder ->
+        return (validationRecord?.toBuilder() ?: LoanValidation.newBuilder()).also { recordBuilder ->
             recordBuilder.addIteration(
                 ValidationIteration.newBuilder().also { iterationBuilder ->
                     iterationBuilder.request = submission

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -18,13 +18,13 @@ import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationResponse
 
-@Participants(roles = [PartyType.OWNER]) // TODO: Ensure Authz grant to validator has been made
+@Participants(roles = [PartyType.OWNER]) // TODO: Change to VALIDATOR once latter is defined
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationResultsContract(
     @Record(LoanScopeFacts.loanValidations) val validationRecord: LoanValidation,
 ) : P8eContract() {
 
-    @Function(invokedBy = PartyType.OWNER) // TODO: Ensure Authz grant to validator has been made
+    @Function(invokedBy = PartyType.OWNER) // TODO: Change to VALIDATOR once latter is defined
     @Record(LoanScopeFacts.loanValidations)
     open fun recordLoanValidationResults(
         @Input(LoanScopeInputs.validationResponse) submission: ValidationResponse
@@ -47,7 +47,7 @@ open class RecordLoanValidationResultsContract(
                 )
             } ?: raiseError("Response is missing results")
             validationRecord.iterationList.singleOrNull { iteration ->
-                iteration.request.requestId == submission.requestId
+                iteration.request.requestId == submission.requestId // For now, we won't support letting results arrive before the request
             }.let { maybeIteration ->
                 requireThat(
                     if (maybeIteration === null) {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -57,9 +57,10 @@ internal enum class ContractRequirementType(
 /**
  * Maps a contract requirement to the appropriate [ContractViolation] that should be raised if it is not met.
  * Equivalent to [kotlin.to].
+ * For convenience, null receivers will not raise a [ContractViolation].
  */
-internal infix fun Boolean.orError(error: ContractViolation): ContractEnforcement =
-    Pair(this, error)
+internal infix fun Boolean?.orError(error: ContractViolation): ContractEnforcement =
+    Pair(this ?: true, error)
 
 internal fun ContractEnforcementContext.raiseError(error: ContractViolation) = requireThat(false to error)
 

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
@@ -19,6 +19,7 @@ import io.provenance.scope.loan.utility.ContractViolationException
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.proto.util.toProtoAny
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
@@ -151,6 +152,7 @@ class RecordLoanContractUnitTest : WordSpec({
                             RecordLoanContract(
                                 existingAsset = existingAsset,
                                 existingENote = ENote.getDefaultInstance(), // Unused
+                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change asset ID"
@@ -180,6 +182,7 @@ class RecordLoanContractUnitTest : WordSpec({
                             RecordLoanContract(
                                 existingAsset = existingAsset,
                                 existingENote = ENote.getDefaultInstance(), // Unused
+                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change asset type"
@@ -223,6 +226,7 @@ class RecordLoanContractUnitTest : WordSpec({
                         RecordLoanContract(
                             existingAsset = existingAsset,
                             existingENote = ENote.getDefaultInstance(), // Unused
+                            existingServicingData = ServicingData.getDefaultInstance(), // Unused
                         ).recordAsset(newAsset)
                     }.let { exception ->
                         exception.message shouldContain
@@ -256,6 +260,7 @@ class RecordLoanContractUnitTest : WordSpec({
                         RecordLoanContract(
                             existingAsset = existingAsset,
                             existingENote = ENote.getDefaultInstance(), // Unused
+                            existingServicingData = ServicingData.getDefaultInstance(), // Unused
                         ).recordAsset(newAsset)
                     }.let { exception ->
                         exception.message shouldContain
@@ -290,6 +295,7 @@ class RecordLoanContractUnitTest : WordSpec({
                             RecordLoanContract(
                                 existingAsset = existingAsset,
                                 existingENote = ENote.getDefaultInstance(), // Unused
+                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change loan ID"
@@ -324,6 +330,7 @@ class RecordLoanContractUnitTest : WordSpec({
                             RecordLoanContract(
                                 existingAsset = existingAsset,
                                 existingENote = ENote.getDefaultInstance(), // Unused
+                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContain "Cannot change loan ULI"
@@ -437,11 +444,6 @@ class RecordLoanContractUnitTest : WordSpec({
         "given an input to an empty scope with a valid eNote" xshould {
             "not throw an exception" {
                 // TODO: Implement
-            }
-        }
-        "given an eNote input to update an existing eNote record" xshould {
-            "throw an appropriate exception" {
-                // TODO: Remove once SkipIfFunctionExists annotation is added to recordENote function
             }
         }
     }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -33,6 +33,7 @@ object Constructors {
         get() = RecordLoanContract(
             existingAsset = Asset.getDefaultInstance(),
             existingENote = ENote.getDefaultInstance(),
+            existingServicingData = ServicingData.getDefaultInstance(),
         )
     val resultsContractWithEmptyExistingRecord: RecordLoanValidationResultsContract
         get() = RecordLoanValidationResultsContract(


### PR DESCRIPTION
### Context
We can finally treat records in our contract constructors as optional with the corresponding [SDK release](https://github.com/provenance-io/p8e-scope-sdk/releases/tag/v0.6.0) and [Gradle plugin release](https://github.com/provenance-io/p8e-gradle-plugin/releases/tag/v0.6.6). For the scope of this PR, we'll configure our contracts to use optional record values, but keep `InitializeLoanScope` defined just in case issues are still discovered.
### Changes
- Implement usage of optional records for contract constructor values
- Bump grpc version to match [p8e-cee-api](https://github.com/provenance-io/p8e-cee-api/blob/65dd7cd9b580da5326a9344ac4da92e45f20ba58/buildSrc/src/main/kotlin/Dependencies.kt#L40)
- Update mostly related TODOs