### PR TITLE
Add repository admins as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# NOTE: Order is important; the last matching pattern takes the
+# most precedence.
+
+# Secondary repo maintainers, substitutes of the primary maintainers when they become MIA
+# * Currently, no accounts other than those listed as the primary maintainers below have write access
+
+# Primary repo maintainers
+* @cworsnop-figure @dkneisly-figure @rpatel-figure


### PR DESCRIPTION
I added the newly updated repository admins as the sole codeowners (derived from [p8e-cee-api](https://github.com/provenance-io/p8e-cee-api/blob/f9da79d42386953d52f24680a96f21bc168a52a3/.github/CODEOWNERS)), and also added branch protection rules for `main`.