### PR TITLE
Start tracking code coverage progress, add function skipping annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,19 @@ on:
         description: Run the linter
         required: false
         default: false
+      runCodeCoverage:
+        type: boolean
+        description: Run code coverage
+        required: false
+        default: true
+      runTestsExtended:
+        type: boolean
+        description: Run the tests without holding back
+        required: false
+        default: true
+
+concurrency:
+  group: ${{ github.ref }}
 
 jobs:
   linting:
@@ -34,7 +47,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-
+    env:
+      RUN_CODE_COVERAGE: ${{ github.event.inputs.runCodeCoverage == true || github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,35 +62,26 @@ jobs:
           java-version: '11'
 
       - name: Build with Gradle
-        run: ./gradlew clean build --refresh-dependencies -Pversion=$VERSION
+        env:
+          RUN_KOTEST_EXTENDED: ${{ github.event.inputs.runTestsExtended == true || github.event.pull_request.draft == false }}
+        run: ./gradlew clean build --refresh-dependencies -Pversion=$VERSION -x koverReport
 
       - name: Check Contract Syntax
         run: ./gradlew p8eClean p8eCheck --info
 
-      - name: Upload Test Results
+      - name: Generate code coverage reports
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+        run: ./gradlew koverReport
+
+      - name: Upload coverage reports
+        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+        uses: codecov/codecov-action@v3
+        with:
+          files: build/reports/kover/report.xml
+
+      - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: "test-results"
           path: "**/build/test-results/**/*.xml"
-
-  publish_test_results:
-    name: Publish Test Results
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    if: always()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: "test-results"
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        with:
-          check_name: "Test Results"
-          pull_request_build: "commit"
-          report_individual_runs: true
-          files: artifacts/**/*.xml

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,45 @@
+name: Publish Test Results
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      pull-requests: write
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          mkdir -p artifacts && cd artifacts
+          
+          artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+          
+          gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+          do
+            IFS=$'\t' read name url <<< "$artifact"
+            gh api $url > "$name.zip"
+            unzip -d "$name" "$name.zip"
+          done
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          check_name: "Test Results"
+          pull_request_build: "commit"
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          report_individual_runs: true
+          files: "artifacts/**/*.xml"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ buildscript {
 plugins {
     pluginSpecs(
         Plugins.KotlinJvm,
+        Plugins.Kover,
         Plugins.GitHubRelease,
         Plugins.NexusPublishing,
         Plugins.P8ePublishing,

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,6 +9,7 @@ object Versions {
     const val Kotlin = "1.6.21"
     const val GitHubRelease = "2.2.12"
     const val Kotest = "5.2.3"
+    const val Kover = "0.5.1"
     const val Ktlint = "0.45.2"
     const val KrotoPlus = "0.6.1"
     const val BouncyCastle = "1.70"
@@ -33,6 +34,7 @@ object Versions {
 object Plugins {
     val Kotlin = PluginSpec("kotlin")
     val KotlinJvm = PluginSpec("org.jetbrains.kotlin.jvm", Versions.Kotlin)
+    val Kover = PluginSpec("org.jetbrains.kotlinx.kover", Versions.Kover)
     val NexusPublishing = PluginSpec("io.github.gradle-nexus.publish-plugin", Versions.Plugins.NexusPublishing)
     val GitHubRelease = PluginSpec("com.github.breadmoirai.github-release", Versions.GitHubRelease)
     val P8ePublishing = PluginSpec("io.provenance.p8e.p8e-publish", Versions.Plugins.P8ePublishing)

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -6,6 +6,7 @@ import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
 import io.provenance.scope.contract.annotations.Record
 import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.annotations.SkipIfRecordExists
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
@@ -16,18 +17,18 @@ import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordENoteContract(
+    @Record(name = LoanScopeFacts.eNote, optional = true) val existingENote: ENote?,
     @Record(name = LoanScopeFacts.servicingData, optional = true) val existingServicingData: ServicingData?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
+    @SkipIfRecordExists(LoanScopeFacts.eNote)
     open fun recordENote(@Input(LoanScopeFacts.eNote) eNote: ENote): ENote = eNote.also(eNoteInputValidation)
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingData)
+    @SkipIfRecordExists(LoanScopeFacts.servicingData)
     open fun recordServicingData(@Input(LoanScopeFacts.servicingData) newServicingData: ServicingData): ServicingData =
-        updateServicingData(
-            existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
-            newServicingData = newServicingData,
-        )
+        updateServicingData(newServicingData = newServicingData)
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -11,26 +11,26 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.documentModificationValidation
 import io.provenance.scope.loan.utility.eNoteDocumentValidation
-import io.provenance.scope.loan.utility.isSet
-import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.util.v1beta1.DocumentMetadata
-// TODO: Potentially remove in favor of append model rather than blanket overwrite
+
 @Participants(roles = [PartyType.OWNER]) // TODO: Change to controller or ensure Authz grant to controller is made
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteContract(
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
+    @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
     open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: DocumentMetadata): ENote {
-        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
-            existingENote.isSet() orError "Cannot create eNote using this contract",
-        )
         validateRequirements(ContractRequirementType.VALID_INPUT) {
             eNoteDocumentValidation(newENote)
+            documentModificationValidation(
+                existingDocument = existingENote.eNote,
+                newDocument = newENote,
+            )
         }
         return existingENote.toBuilder().setENote(newENote).build()
     }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerContract.kt
@@ -13,22 +13,17 @@ import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
 import io.provenance.scope.loan.utility.eNoteControllerValidation
-import io.provenance.scope.loan.utility.isSet
-import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.validateRequirements
 
 @Participants([PartyType.OWNER, PartyType.CUSTODIAN]) // TODO: Change temporary placeholder of "CUSTODIAN" to "CONTROLLER" once latter is defined
 @ScopeSpecification(["tech.figure.loan"])
 open class UpdateENoteControllerContract(
-    @Record(LoanScopeFacts.eNote) val existingENote: ENote,
+    @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.CUSTODIAN) // TODO: Change temporary placeholder of "CUSTODIAN" to "CONTROLLER" once latter is defined
     @Record(LoanScopeFacts.eNote)
     open fun updateENoteController(@Input(LoanScopeInputs.eNoteControllerUpdate) newController: Controller): ENote {
-        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
-            existingENote.isSet() orError "Cannot create eNote using this contract",
-        )
         validateRequirements(ContractRequirementType.VALID_INPUT) {
             eNoteControllerValidation(newController)
         }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -11,7 +11,7 @@ import tech.figure.util.v1beta1.Money as FigureTechMoney
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 @Suppress("TooGenericExceptionCaught")
-internal fun tryOrFalse(fn: () -> Any): Boolean =
+internal fun <T> tryOrFalse(fn: () -> T): Boolean =
     try {
         fn()
         true

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
@@ -1,0 +1,43 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.core.spec.style.WordSpec
+
+class AppendLoanDocumentsContractUnitTest : WordSpec({
+    "appendDocuments" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input to an empty scope with at least one invalid document" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input with at least one invalid document to append to existing documents in the scope" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given input documents which duplicate existing document checksums" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given input documents with duplicate checksums" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input which attempts to silently change properties of one or more existing documents" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContractUnitTest.kt
@@ -14,6 +14,7 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.checkAll
 import io.provenance.scope.loan.test.Constructors.appendLoanStatesContractWithNoExistingStates
+import io.provenance.scope.loan.test.KotestConfig
 import io.provenance.scope.loan.test.LoanPackageArbs.anyUuid
 import io.provenance.scope.loan.test.LoanPackageArbs.anyValidChecksum
 import io.provenance.scope.loan.test.LoanPackageArbs.anyValidLoanState
@@ -36,14 +37,14 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                 }
             }
         }
-        "given at least one loan state with invalid fields" should {
+        "given at least one input loan state with invalid fields" should {
             "throw an appropriate exception" {
-                checkAll(anyValidLoanState) { randomLoanState ->
+                checkAll(anyValidLoanState) { randomValidLoanState ->
                     shouldThrow<ContractViolationException> {
                         appendLoanStatesContractWithNoExistingStates.appendLoanStates(
                             listOf(
                                 LoanStateMetadata.getDefaultInstance(),
-                                randomLoanState,
+                                randomValidLoanState,
                             )
                         )
                     }.let { exception ->
@@ -54,7 +55,7 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                 }
             }
         }
-        "given loan states which duplicate existing loan state checksums" should {
+        "given input loan states which duplicate existing loan state checksums" should {
             "throw an appropriate exception" {
                 checkAll(anyValidLoanState, anyValidLoanState, anyValidChecksum) { randomExistingLoanState, randomNewLoanState, randomChecksum ->
                     shouldThrow<ContractViolationException> {
@@ -80,7 +81,7 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                 }
             }
         }
-        "given loan states which duplicate existing loan state IDs" should {
+        "given input loan states which duplicate existing loan state IDs" should {
             "throw an appropriate exception" {
                 checkAll(anyValidLoanState, anyValidLoanState, anyUuid) { randomExistingLoanState, randomNewLoanState, randomUuid ->
                     shouldThrow<ContractViolationException> {
@@ -106,7 +107,7 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                 }
             }
         }
-        "given loan states which duplicate existing loan state times" should {
+        "given input loan states which duplicate existing loan state times" should {
             "throw an appropriate exception" {
                 checkAll(anyValidLoanState, anyValidLoanState, anyValidTimestamp) { randomExistingLoanState, randomNewLoanState, randomTimestamp ->
                     shouldThrow<ContractViolationException> {
@@ -132,9 +133,24 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                 }
             }
         }
-        "given only new & valid loan states" should {
+        "given an input of loan states with duplicate checksums" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input of loan states with duplicate IDs" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input of loan states with duplicate times" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given only new & valid input loan states" should {
             "not throw an exception" {
-                val stateCountRange = 2..4 // Reduce the upper bound of this range (to no lower than 3) to decrease the execution time
+                val stateCountRange = 2..(if (KotestConfig.runTestsExtended) 4 else 3) // Keep upper bound low since runtime is Θ(n^2)
                 val arbitraryStateCountAndSplit = Arb.int(stateCountRange).flatMap { randomStateCount ->
                     Arb.pair(arbitrary { randomStateCount }, Arb.int(0..max(randomStateCount - 1, 1)))
                 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/OverwriteServicingRightsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/OverwriteServicingRightsUnitTest.kt
@@ -1,0 +1,40 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.core.spec.style.WordSpec
+
+class OverwriteServicingRightsUnitTest : WordSpec({
+    "A function initializing the servicing rights record" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "A function overwriting the existing servicing rights record" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
@@ -1,0 +1,50 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.core.spec.style.WordSpec
+
+class RecordENoteContractUnitTest : WordSpec({
+    "recordENote" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input to an empty scope" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "recordServicingData" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input to an empty scope" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input to update the existing servicing data record" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input to an empty scope" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input to update the existing servicing data record" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
@@ -10,16 +10,19 @@ import io.kotest.property.checkAll
 import io.provenance.scope.loan.LoanScopeProperties.assetLoanKey
 import io.provenance.scope.loan.LoanScopeProperties.assetMismoKey
 import io.provenance.scope.loan.test.Constructors.recordContractWithEmptyScope
+import io.provenance.scope.loan.test.LoanPackageArbs.anyInvalidUuid
 import io.provenance.scope.loan.test.LoanPackageArbs.anyNonEmptyString
 import io.provenance.scope.loan.test.LoanPackageArbs.anyNonUliString
-import io.provenance.scope.loan.test.LoanPackageArbs.anyNonUuidString
-import io.provenance.scope.loan.test.LoanPackageArbs.anyUli
 import io.provenance.scope.loan.test.LoanPackageArbs.anyUuid
+import io.provenance.scope.loan.test.LoanPackageArbs.anyValidFigureTechLoan
+import io.provenance.scope.loan.test.LoanPackageArbs.anyValidMismoLoan
+import io.provenance.scope.loan.test.LoanPackageArbs.anyValidUli
 import io.provenance.scope.loan.utility.ContractViolationException
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.proto.util.toProtoAny
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
+import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
@@ -70,11 +73,9 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input to an empty scope with invalid asset data" should {
             "throw an appropriate exception" {
-                checkAll(anyNonUuidString) { randomInvalidAssetId ->
+                checkAll(anyInvalidUuid) { randomInvalidAssetId ->
                     Asset.newBuilder().also { assetBuilder ->
-                        assetBuilder.id = FigureTechUUID.newBuilder().also { idBuilder ->
-                            idBuilder.value = randomInvalidAssetId
-                        }.build()
+                        assetBuilder.id = randomInvalidAssetId
                     }.build().let { assetWithInvalidId ->
                         shouldThrow<ContractViolationException> {
                             recordContractWithEmptyScope.recordAsset(assetWithInvalidId)
@@ -87,16 +88,14 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input to an empty scope with invalid Figure Tech loan data" should {
             "throw an appropriate exception" {
-                checkAll(anyUuid, anyNonEmptyString, anyNonUuidString) { randomAssetId, randomType, randomInvalidLoanId ->
+                checkAll(anyUuid, anyNonEmptyString, anyInvalidUuid) { randomAssetId, randomType, randomInvalidLoanId ->
                     Asset.newBuilder().also { assetBuilder ->
                         assetBuilder.id = randomAssetId
                         assetBuilder.type = randomType
                         assetBuilder.putKv(
                             "loan",
                             FigureTechLoan.newBuilder().also { loanBuilder ->
-                                loanBuilder.id = FigureTechUUID.newBuilder().also { idBuilder ->
-                                    idBuilder.value = randomInvalidLoanId
-                                }.build()
+                                loanBuilder.id = randomInvalidLoanId
                             }.build().toProtoAny()
                         )
                     }.build().let { assetWithInvalidId ->
@@ -151,8 +150,10 @@ class RecordLoanContractUnitTest : WordSpec({
                         shouldThrow<ContractViolationException> {
                             RecordLoanContract(
                                 existingAsset = existingAsset,
-                                existingENote = ENote.getDefaultInstance(), // Unused
-                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                                // The rest of the parameters are not relevant to this test case
+                                existingENote = ENote.getDefaultInstance(),
+                                existingServicingData = ServicingData.getDefaultInstance(),
+                                existingServicingRights = ServicingRights.getDefaultInstance(),
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change asset ID"
@@ -181,8 +182,10 @@ class RecordLoanContractUnitTest : WordSpec({
                         shouldThrow<ContractViolationException> {
                             RecordLoanContract(
                                 existingAsset = existingAsset,
-                                existingENote = ENote.getDefaultInstance(), // Unused
-                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                                // The rest of the parameters are not relevant to this test case
+                                existingENote = ENote.getDefaultInstance(),
+                                existingServicingData = ServicingData.getDefaultInstance(),
+                                existingServicingRights = ServicingRights.getDefaultInstance(),
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change asset type"
@@ -203,7 +206,7 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input with a loan of a different type than the existing Figure Tech loan" should {
             "throw an appropriate exception" {
-                checkAll(anyUuid, anyUuid, anyUli) { randomAssetId, randomLoanId, randomUli ->
+                checkAll(anyUuid, anyUuid, anyValidUli) { randomAssetId, randomLoanId, randomUli ->
                     val existingAsset = Asset.newBuilder().also { assetBuilder ->
                         assetBuilder.id = randomAssetId // To mark the existing asset as being set
                         assetBuilder.putKv(
@@ -225,8 +228,10 @@ class RecordLoanContractUnitTest : WordSpec({
                     shouldThrow<ContractViolationException> {
                         RecordLoanContract(
                             existingAsset = existingAsset,
-                            existingENote = ENote.getDefaultInstance(), // Unused
-                            existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                            // The rest of the parameters are not relevant to this test case
+                            existingENote = ENote.getDefaultInstance(),
+                            existingServicingData = ServicingData.getDefaultInstance(),
+                            existingServicingRights = ServicingRights.getDefaultInstance(),
                         ).recordAsset(newAsset)
                     }.let { exception ->
                         exception.message shouldContain
@@ -237,7 +242,7 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input with a loan of a different type than the existing MISMO loan" should {
             "throw an appropriate exception" {
-                checkAll(anyUuid, anyUuid, anyUli) { randomAssetId, randomLoanId, randomUli ->
+                checkAll(anyUuid, anyUuid, anyValidUli) { randomAssetId, randomLoanId, randomUli ->
                     val existingAsset = Asset.newBuilder().also { assetBuilder ->
                         assetBuilder.id = randomAssetId // To mark the existing asset as being set
                         assetBuilder.putKv(
@@ -259,8 +264,10 @@ class RecordLoanContractUnitTest : WordSpec({
                     shouldThrow<ContractViolationException> {
                         RecordLoanContract(
                             existingAsset = existingAsset,
-                            existingENote = ENote.getDefaultInstance(), // Unused
-                            existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                            // The rest of the parameters are not relevant to this test case
+                            existingENote = ENote.getDefaultInstance(),
+                            existingServicingData = ServicingData.getDefaultInstance(),
+                            existingServicingRights = ServicingRights.getDefaultInstance(),
                         ).recordAsset(newAsset)
                     }.let { exception ->
                         exception.message shouldContain
@@ -294,8 +301,10 @@ class RecordLoanContractUnitTest : WordSpec({
                         shouldThrow<ContractViolationException> {
                             RecordLoanContract(
                                 existingAsset = existingAsset,
-                                existingENote = ENote.getDefaultInstance(), // Unused
-                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                                // The rest of the parameters are not relevant to this test case
+                                existingENote = ENote.getDefaultInstance(),
+                                existingServicingData = ServicingData.getDefaultInstance(),
+                                existingServicingRights = ServicingRights.getDefaultInstance(),
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContainIgnoringCase "Cannot change loan ID"
@@ -306,7 +315,7 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input with invalid changes to the existing MISMO loan" should {
             "throw an appropriate exception" {
-                checkAll(anyUli, anyUli, anyUuid) { randomExistingUli, randomNewUli, randomAssetId ->
+                checkAll(anyValidUli, anyValidUli, anyUuid) { randomExistingUli, randomNewUli, randomAssetId ->
                     val existingAsset = Asset.newBuilder().also { assetBuilder ->
                         assetBuilder.id = randomAssetId // To mark the existing asset as being set
                         assetBuilder.putKv(
@@ -329,8 +338,10 @@ class RecordLoanContractUnitTest : WordSpec({
                         shouldThrow<ContractViolationException> {
                             RecordLoanContract(
                                 existingAsset = existingAsset,
-                                existingENote = ENote.getDefaultInstance(), // Unused
-                                existingServicingData = ServicingData.getDefaultInstance(), // Unused
+                                // The rest of the parameters are not relevant to this test case
+                                existingENote = ENote.getDefaultInstance(),
+                                existingServicingData = ServicingData.getDefaultInstance(),
+                                existingServicingRights = ServicingRights.getDefaultInstance(),
                             ).recordAsset(newAsset)
                         }.let { exception ->
                             exception.message shouldContain "Cannot change loan ULI"
@@ -341,59 +352,36 @@ class RecordLoanContractUnitTest : WordSpec({
         }
         "given an input to an empty scope with a valid Figure Tech loan" should {
             "not throw an exception" {
-                checkAll(anyUuid, anyUuid, anyNonEmptyString, anyNonEmptyString) { randomAssetId, randomLoanId, randomType, randomOriginatorName ->
+                checkAll(anyUuid, anyNonEmptyString, anyValidFigureTechLoan) { randomAssetId, randomType, randomLoan ->
                     recordContractWithEmptyScope.recordAsset(
                         Asset.newBuilder().apply {
                             id = randomAssetId
                             type = randomType
-                            putKv(
-                                "loan",
-                                FigureTechLoan.newBuilder().also { loanBuilder ->
-                                    loanBuilder.id = randomLoanId
-                                    loanBuilder.originatorName = randomOriginatorName
-                                }.build().toProtoAny()
-                            )
+                            putKv("loan", randomLoan.toProtoAny())
                         }.build()
                     )
                 }
             }
         }
-        "given an valid Figure Tech loan input to update an existing asset record" xshould {
+        "given a valid Figure Tech loan input to update an existing asset record" xshould {
             "not throw an exception" {
                 // TODO: Implement
             }
         }
         "given an input to an empty scope with a valid MISMO loan" should {
             "not throw an exception" {
-                checkAll(anyUuid, anyUli, anyNonEmptyString) { randomAssetId, randomUli, randomType ->
+                checkAll(anyUuid, anyNonEmptyString, anyValidMismoLoan) { randomAssetId, randomType, randomLoan ->
                     recordContractWithEmptyScope.recordAsset(
                         Asset.newBuilder().apply {
                             id = randomAssetId
                             type = randomType
-                            putKv(
-                                "mismoLoan",
-                                MISMOLoanMetadata.newBuilder().also { loanBuilder ->
-                                    loanBuilder.uli = randomUli
-                                }.build().toProtoAny()
-                            )
+                            putKv("mismoLoan", randomLoan.toProtoAny())
                         }.build()
                     )
                 }
             }
         }
         "given an valid MISMO loan input to update an existing asset record" xshould {
-            "not throw an exception" {
-                // TODO: Implement
-            }
-        }
-    }
-    "recordServicingRights" When {
-        "given an invalid input" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given an valid input" xshould {
             "not throw an exception" {
                 // TODO: Implement
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
@@ -1,0 +1,28 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.core.spec.style.WordSpec
+
+class UpdateENoteContractUnitTest : WordSpec({
+    "updateENote" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an input which attempts to silently change properties of the existing eNote" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerUnitTest.kt
@@ -1,0 +1,23 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.core.spec.style.WordSpec
+
+class UpdateENoteControllerUnitTest : WordSpec({
+    "updateENoteController" When {
+        "given an empty input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given an invalid input" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a valid input" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -8,6 +8,7 @@ import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
 import io.provenance.scope.util.toProtoTimestamp
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
+import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationItem
 import tech.figure.validation.v1beta1.ValidationIteration
@@ -34,6 +35,7 @@ object Constructors {
             existingAsset = Asset.getDefaultInstance(),
             existingENote = ENote.getDefaultInstance(),
             existingServicingData = ServicingData.getDefaultInstance(),
+            existingServicingRights = ServicingRights.getDefaultInstance(),
         )
     val resultsContractWithEmptyExistingRecord: RecordLoanValidationResultsContract
         get() = RecordLoanValidationResultsContract(
@@ -51,7 +53,7 @@ object Constructors {
     ): ValidationRequest = ValidationRequest.newBuilder().also { requestBuilder ->
         requestBuilder.requestId = requestID
         requestBuilder.ruleSetId = randomProtoUuid
-        requestBuilder.snapshotUri = randomProtoUuid.value
+        requestBuilder.snapshotUri = randomProtoUuid.value // TODO: Change to block height in model v0.1.9
         requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
         requestBuilder.requesterName = requesterName
         requestBuilder.validatorName = validatorName

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestConfig.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestConfig.kt
@@ -3,7 +3,10 @@ package io.provenance.scope.loan.test
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.SpecExecutionOrder
 
-class KotestConfig : AbstractProjectConfig() {
+object KotestConfig : AbstractProjectConfig() {
     override val specExecutionOrder = SpecExecutionOrder.Random
-    override val parallelism = 2 // An experimental value - greater values may still improve performance
+    override val parallelism = 4 // An experimental value - greater values may still improve performance
+    /** Runs tests without cutting corners in edge cases or iteration counts. If true, will greatly increase time for tests to run. */
+    val runTestsExtended: Boolean
+        get() = System.getenv("RUN_KOTEST_EXTENDED") == "true"
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -77,6 +77,11 @@ class ContractRequirementsUnitTest : WordSpec({
             }
         }
         "invoked with a function body" should {
+            "!properly handle calling requireThatEach on a collection with violations in multiple iterations" {
+                shouldThrow<IllegalContractStateException> {
+                    // TODO: Implement
+                }
+            }
             "return state violations only for failed conditions" {
                 checkAll(
                     Arb.list(LoanPackageArbs.anyContractEnforcement),

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
@@ -15,54 +15,93 @@ import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 class DataConversionExtensionsUnitTest : WordSpec({
-    // TODO: Introduce top-level When block for each data conversion function being tested
-    "unpackAs" should {
-        "successfully unpack a packed protobuf as the same type that was packed" {
-            checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
-                shouldNotThrow<UnexpectedContractStateException> {
-                    randomChecksum.toProtoAny().unpackAs<FigureTechChecksum>() shouldBe randomChecksum
-                }
-            }
-        }
-        "fail to unpack a packed protobuf as a type with inherently different fields" {
-            checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
-                shouldThrow<UnexpectedContractStateException> {
-                    randomChecksum.toProtoAny().unpackAs<FigureTechUUID>()
-                }.let { exception ->
-                    exception shouldBeParseFailureFor "tech.figure.util.v1beta1.UUID"
-                }
-            }
-        }
-    }
-    "tryUnpackingAs" xshould {
-        // TODO: Implement
-    }
-    "toFigureTechLoan" should {
-        "throw an exception for unpacking when called on a non-nullable inapplicable protobuf" {
-            checkAll(Arb.string(), Arb.string()) { randomChecksumString, randomAlgorithmString ->
-                FigureTechChecksum.newBuilder().apply {
-                    checksum = randomChecksumString
-                    algorithm = randomAlgorithmString
-                }.build().let { randomChecksum ->
-                    shouldThrow<UnexpectedContractStateException> {
-                        randomChecksum?.toProtoAny()?.toFigureTechLoan()
-                    }.let { exception ->
-                        exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
+    "unpackAs" When {
+        "given a packed protobuf to unpack as the same type it was packed as" should {
+            "not throw an exception" {
+                checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
+                    shouldNotThrow<UnexpectedContractStateException> {
+                        randomChecksum.toProtoAny().unpackAs<FigureTechChecksum>() shouldBe randomChecksum
                     }
-                    IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
-                        shouldThrow<IllegalArgumentException> { // Sanity check that parsing is only attempted when intended by code
-                            randomChecksum.takeIf { false }?.toProtoAny()?.toFigureTechLoan()
-                                ?: throw callerException
-                        }.let { thrownException ->
-                            thrownException shouldBe callerException
+                }
+            }
+        }
+        "given a packed protobuf to unpack as a type with inherently different fields than the type it was packed as" should {
+            "throw an appropriate exception" {
+                checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        randomChecksum.toProtoAny().unpackAs<FigureTechUUID>()
+                    }.let { exception ->
+                        exception shouldBeParseFailureFor "tech.figure.util.v1beta1.UUID"
+                    }
+                }
+            }
+        }
+    }
+    "tryUnpackingAs" When {
+        "given a packed protobuf to unpack as the same type it was packed as" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
+        "given a packed protobuf to unpack as a type with inherently different fields than the type it was packed as" xshould {
+            "throw an appropriate exception" {
+                // TODO: Implement
+            }
+        }
+        "given a packed Figure Tech loan to unpack as a MISMO loan with inherently different fields" xshould {
+            "throw an appropriate informative exception" {
+                // TODO: Implement
+            }
+        }
+        "given a packed MISMO loan to unpack as a Figure Tech loan with inherently different fields" xshould {
+            "throw an appropriate informative exception" {
+                // TODO: Implement
+            }
+        }
+    }
+    "toFigureTechLoan" When {
+        "called on a non-null inapplicable protobuf" should {
+            "throw an appropriate exception for unpacking" {
+                checkAll(Arb.string(), Arb.string()) { randomChecksumString, randomAlgorithmString ->
+                    FigureTechChecksum.newBuilder().apply {
+                        checksum = randomChecksumString
+                        algorithm = randomAlgorithmString
+                    }.build().let { randomChecksum ->
+                        shouldThrow<UnexpectedContractStateException> {
+                            randomChecksum?.toProtoAny()?.toFigureTechLoan()
+                        }.let { exception ->
+                            exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
+                        }
+                        // Sanity check that parsing is only attempted when intended by code
+                        IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
+                            shouldThrow<IllegalArgumentException> {
+                                randomChecksum.takeIf { false }?.toProtoAny()?.toFigureTechLoan()
+                                    ?: throw callerException
+                            }.let { thrownException ->
+                                thrownException shouldBe callerException
+                            }
                         }
                     }
                 }
             }
         }
+        "called on a packed Figure Tech loan" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
     }
     "toMISMOLoan" xshould {
-        // TODO: Implement
+        "called on a non-null inapplicable protobuf" xshould {
+            "throw an appropriate exception for unpacking" {
+                // TODO: Implement
+            }
+        }
+        "called on a packed MISMO loan" xshould {
+            "not throw an exception" {
+                // TODO: Implement
+            }
+        }
     }
 }) {
     override fun testCaseOrder() = TestCaseOrder.Random


### PR DESCRIPTION
## Context
Now that optional record support has proven to be working, we can update the contracts to properly use `SkipIfRecordExists` for functions which are meant to initialize but never subsequently update a particular record. With that change, the basic functionality of all contracts should be available for use. Thus, before we add the remaining tests, let's start tracking code coverage to see the remaining progression and ensure development becomes fully test-driven.
## Changes
### Major
- Modify constructors of eNote contracts to
  - use optional or required existing eNote record depending on whether it is allowed to update the record or not
  - use `@SkipIfRecordExists` in eNote record initialization contracts to ensure only eNote-updating contracts can do so
- Add [Kover](https://github.com/Kotlin/kotlinx-kover) to build workflow
### Minor
- DRY some data validation functions
- Improve the usage and/or signatures of some data validation functions
- Outline basic plan for remaining tests
- Add configurable code coverage & linting usage to build workflow dispatch
- Try increasing Kotest thread count from 2 to 4 & introducing environment variable for toggling edge case thoroughness
- Add concurrency for build workflow
- Update comments
- Improve some minor details in utility package code