### PR TITLE
Fix unit test result publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,3 +85,13 @@ jobs:
         with:
           name: "test-results"
           path: "**/build/test-results/**/*.xml"
+
+  event_file:
+    name: "Upload event file"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload event file
+        uses: actions/upload-artifact@v3
+        with:
+          name: Event File
+          path: ${{ github.event_path }}


### PR DESCRIPTION
### Context
All the test publishing workflows runs have been failing with [the following error](https://github.com/provenance-io/loan-package-contracts/runs/6696949013?check_suite_focus=true#step:4:29):
```
Traceback (most recent call last):
  File "/action/publish_unit_test_results.py", line 331, in <module>
    settings = get_settings(options, gha)
  File "/action/publish_unit_test_results.py", line 239, in get_settings
    with open(event, 'rt', encoding='utf-8') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'artifacts/Event File/event.json'
```
This is because in #24, I forgot to add the event file upload at the end of the code snippet provided [here](https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches).