### PR TITLE
Let baseline code coverage generate in main, auto-cancel concurrent runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
     types: [ synchronize, opened, reopened, ready_for_review, converted_to_draft ]
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       linting:
@@ -23,6 +26,7 @@ on:
 
 concurrency:
   group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:
@@ -48,7 +52,12 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     env:
-      RUN_CODE_COVERAGE: ${{ github.event.inputs.runCodeCoverage == true || github.event.pull_request.draft == false }}
+      RUN_CODE_COVERAGE: |
+        ${{
+          github.event.inputs.runCodeCoverage == true ||
+          github.event.pull_request.draft == false ||
+          github.event.push == true
+        }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Context
- In order for Code Coverage to properly report the difference in code coverage for a pull request, code coverage must have been generated for the branch being merged into so that the two reports can be compared. This was not happening for `main` and was resulting in the Codecov commenter bot saying

  > :exclamation: No coverage uploaded for pull request base (`main@commitHashHere`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference?utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=provenance-io#section-missing-base-commit).
  > The diff coverage is `n/a`.
- Now that the test source takes a significant amount of time to run, we should start cancelling previous in-progress runs