### PR TITLE
Get closer to sufficient code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,17 +46,17 @@ jobs:
           java-version: '11'
 
       - name: Linting
-        run: ./gradlew clean ktlintCheck --parallel
+        run: ./gradlew clean ktlintCheck --parallel --refresh-dependencies
 
   build:
     name: Build
     runs-on: ubuntu-latest
     env:
-      RUN_CODE_COVERAGE: |
+      RUN_CODE_COVERAGE:
         ${{
-          github.event.inputs.runCodeCoverage == true ||
-          github.event.pull_request.draft == false ||
-          github.event.push == true
+          github.event.inputs.runCodeCoverage == 'true' ||
+          github.event.pull_request.draft == 'false' ||
+          github.event.push == 'true'
         }}
     steps:
       - name: Checkout
@@ -72,18 +72,18 @@ jobs:
 
       - name: Build with Gradle
         env:
-          RUN_KOTEST_EXTENDED: ${{ github.event.inputs.runTestsExtended == true || github.event.pull_request.draft == false }}
+          RUN_KOTEST_EXTENDED: ${{ github.event.inputs.runTestsExtended == 'true' || github.event.pull_request.draft == 'false' }}
         run: ./gradlew clean build --refresh-dependencies -Pversion=$VERSION -x koverReport
 
       - name: Check Contract Syntax
         run: ./gradlew p8eClean p8eCheck --info
 
       - name: Generate code coverage reports
-        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+        if: env.RUN_CODE_COVERAGE == 'true'
         run: ./gradlew koverReport
 
       - name: Upload coverage reports
-        if: ${{ env.RUN_CODE_COVERAGE == 'true' }}
+        if: env.RUN_CODE_COVERAGE == 'true'
         uses: codecov/codecov-action@v3
         with:
           files: build/reports/kover/report.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,6 +118,7 @@ subprojects {
     apply {
         plugin("signing")
     }
+
     java {
         withJavadocJar()
         withSourcesJar()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -24,6 +24,8 @@ object Versions {
         const val ProtocGenValidate = "0.6.7"
         const val Protobuf = "3.20.1"
         const val SemVer = "1.1.2"
+        const val JacksonKotlin = "2.13.3"
+        const val JacksonProtobuf = "0.9.12"
         object Provenance {
             const val Scope = "0.6.0"
             const val MetadataAssetModel = "0.1.9"
@@ -85,6 +87,16 @@ object Dependencies {
             exclude = setOf(
                 "com.google.protobuf:protobuf-java",
             )
+        )
+    }
+    object Jackson {
+        val KotlinModule = DependencySpec(
+            name = "com.fasterxml.jackson.module:jackson-module-kotlin",
+            version = Versions.Dependencies.JacksonKotlin,
+        )
+        val ProtobufModule = DependencySpec(
+            name = "com.hubspot.jackson:jackson-datatype-protobuf",
+            version = Versions.Dependencies.JacksonProtobuf,
         )
     }
     object Protobuf {

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
         Dependencies.Kotest.Framework,
         Dependencies.Kotest.Assertions,
         Dependencies.Kotest.Property,
+        Dependencies.Jackson.KotlinModule,
+        Dependencies.Jackson.ProtobufModule,
     )
 }
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
@@ -44,7 +44,7 @@ open class AppendLoanDocumentsContract(
                 documentValidation(newDocument)
                 newDocument.checksum.checksum?.let { newDocChecksum ->
                     if (incomingDocChecksums[newDocChecksum] == true) {
-                        raiseError("Loan document with checksum $newDocChecksum already provided in input")
+                        raiseError("Loan document with checksum $newDocChecksum is provided more than once in input")
                     }
                     existingDocumentMetadata[newDocChecksum]?.let { existingDocument ->
                         documentModificationValidation(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -30,7 +30,7 @@ open class RecordLoanValidationResultsContract(
         @Input(LoanScopeInputs.validationResponse) submission: ValidationResponse
     ): LoanValidation {
         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE,
-            validationRecord.isSet() orError "A validation iteration must exist for results to be submitted",
+            validationRecord.isSet() orError "A validation iteration must already exist for results to be submitted",
         )
         validateRequirements(ContractRequirementType.VALID_INPUT) {
             requireThat(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -22,6 +22,9 @@ open class UpdateENoteContract(
     @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
 ) : P8eContract() {
 
+    /**
+     * TODO: We may need to replace this with AddENoteModification and AddENoteAssumption contracts, pending more insight on that process
+     */
     @Function(invokedBy = PartyType.OWNER) // TODO: Change to controller or ensure Authz grant to controller is made
     @Record(LoanScopeFacts.eNote)
     open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: DocumentMetadata): ENote {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/Exceptions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/Exceptions.kt
@@ -10,7 +10,9 @@ class UnexpectedContractStateException(message: String, cause: Exception?) : Ill
 /**
  * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed for an inapplicable loan scope.
  */
-class IllegalContractStateException(message: String) : IllegalStateException(message)
+class IllegalContractStateException(message: String, cause: Exception?) : IllegalStateException(message, cause) {
+    constructor(message: String) : this(message, null)
+}
 
 /**
  * Denotes an [Exception] thrown by [validateRequirements] when a contract is executed with invalid input.

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
@@ -3,6 +3,7 @@ package io.provenance.scope.loan.utility
 import io.provenance.scope.util.toOffsetDateTime
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
+import tech.figure.util.v1beta1.DocumentMetadata
 
 internal fun updateServicingData(
     existingServicingData: ServicingData = ServicingData.getDefaultInstance(),
@@ -11,10 +12,13 @@ internal fun updateServicingData(
     validateRequirements(ContractRequirementType.VALID_INPUT) {
         // TODO: Validate any other top-level fields of newServicingData?
         // TODO: Which top-level fields of the servicing data record other than the loan states should be updatable? Does it vary between contracts?
-        servicingDataBuilder.docMetaList.forEach { document ->
-            documentValidation(document)
-        }
-        appendLoanStates(servicingDataBuilder, newServicingData.loanStateList)
+        newServicingData.takeIf { it.isSet() }?.let {
+            servicingDataBuilder.docMetaList.forEach { document ->
+                documentValidation(document)
+            }
+            appendLoanStates(servicingDataBuilder, newServicingData.loanStateList)
+            appendServicingDocuments(servicingDataBuilder, newServicingData.docMetaList)
+        } ?: raiseError("Servicing data is not set")
     }
 }.build()
 
@@ -51,7 +55,7 @@ internal fun ContractEnforcementContext.appendLoanStates(
         state.checksum?.checksum?.let { checksum ->
             requireThat(!existingStateChecksums.getOrDefault(checksum, false) orError "Loan state with checksum $checksum already exists")
             requireThat(
-                !incomingStateChecksums.getOrDefault(checksum, false) orError "Loan state with checksum $checksum already provided in input"
+                !incomingStateChecksums.getOrDefault(checksum, false) orError "Loan state with checksum $checksum is provided more than once in input"
             )
             if (checksum.isNotBlank()) {
                 incomingStateChecksums[checksum] = true
@@ -60,7 +64,7 @@ internal fun ContractEnforcementContext.appendLoanStates(
         state.id?.value?.let { id ->
             requireThat(!existingStateIds.getOrDefault(id, false) orError "Loan state with ID $id already exists")
             requireThat(
-                !incomingStateIds.getOrDefault(id, false) orError "Loan state with ID $id already provided in input"
+                !incomingStateIds.getOrDefault(id, false) orError "Loan state with ID $id is provided more than once in input"
             )
             if (id.isNotBlank()) {
                 incomingStateIds[id] = true
@@ -73,7 +77,7 @@ internal fun ContractEnforcementContext.appendLoanStates(
             )
             requireThat(
                 !incomingStateTimes.getOrDefault(effectiveTime.seconds to effectiveTime.nanos, false)
-                    orError "Loan state with effective time ${effectiveTime.toOffsetDateTime()} already provided in input"
+                    orError "Loan state with effective time ${effectiveTime.toOffsetDateTime()} is provided more than once in input"
             )
             if (effectiveTime.isValid()) {
                 incomingStateTimes[effectiveTime.seconds to effectiveTime.nanos] = true
@@ -81,5 +85,34 @@ internal fun ContractEnforcementContext.appendLoanStates(
         }
         /* Append new data - if a violation was found, the eventual thrown exception prevents the changes from persisting */
         servicingDataBuilder.addLoanState(state)
+    }
+}
+
+internal fun ContractEnforcementContext.appendServicingDocuments(
+    servicingDataBuilder: ServicingData.Builder,
+    newDocuments: Collection<DocumentMetadata>,
+) {
+    val existingDocumentMetadata = mutableMapOf<String, DocumentMetadata>()
+    servicingDataBuilder.docMetaList.forEach { documentMetadata ->
+        documentMetadata.checksum.takeIf { it.isSet() }?.checksum?.let { checksum ->
+            existingDocumentMetadata[checksum] = documentMetadata
+        }
+    }
+    val incomingDocumentChecksums = mutableMapOf<String, Boolean>()
+    for (newDocument in newDocuments) {
+        documentValidation(newDocument)
+        newDocument.checksum.checksum?.let { newDocChecksum ->
+            if (incomingDocumentChecksums[newDocChecksum] == true) {
+                raiseError("Loan document with checksum $newDocChecksum is provided more than once in input")
+            }
+            existingDocumentMetadata[newDocChecksum]?.let { existingDocument ->
+                documentModificationValidation(
+                    existingDocument,
+                    newDocument,
+                )
+            }
+            /* Append new data - if a violation was found, the eventual thrown exception prevents the changes from persisting */
+            servicingDataBuilder.addDocMeta(newDocument)
+        }
     }
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
@@ -1,43 +1,171 @@
 package io.provenance.scope.loan.contracts
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.set
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuidSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidLoanDocumentSet
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.breakOffLast
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.test.toPair
+import io.provenance.scope.loan.test.toRecord
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.loan.v1beta1.LoanDocuments
+import tech.figure.util.v1beta1.DocumentMetadata
+import kotlin.math.max
 
 class AppendLoanDocumentsContractUnitTest : WordSpec({
     "appendDocuments" When {
-        "given an empty input" xshould {
+        val maxDocumentCount = (if (KotestConfig.runTestsExtended) 20 else 5)
+        "given an empty input" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(
+                    Arb.int(min = 0, max = maxDocumentCount).flatMap { existingDocumentCount ->
+                        anyValidLoanDocumentSet(size = existingDocumentCount)
+                    },
+                ) { randomExistingDocuments ->
+                    shouldThrow<ContractViolationException> {
+                        AppendLoanDocumentsContract(
+                            existingDocs = randomExistingDocuments,
+                        ).appendDocuments(
+                            newDocs = LoanDocuments.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Must supply at least one document"
+                    }
+                }
             }
         }
-        "given an input to an empty scope with at least one invalid document" xshould {
+        "given an input to an empty scope with at least one invalid document" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                shouldThrow<ContractViolationException> {
+                    AppendLoanDocumentsContract(
+                        existingDocs = LoanDocuments.getDefaultInstance(),
+                    ).appendDocuments(
+                        newDocs = LoanDocuments.newBuilder().also { inputBuilder ->
+                            inputBuilder.clearDocument()
+                            inputBuilder.addDocument(DocumentMetadata.getDefaultInstance())
+                        }.build()
+                    )
+                }.let { exception ->
+                    exception shouldHaveViolationCount 1U
+                    exception.message shouldContain "Document is not set"
+                }
             }
         }
-        "given an input with at least one invalid document to append to existing documents in the scope" xshould {
+        "given an input with at least one invalid document to append to existing documents in the scope" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(
+                    Arb.int(min = 1, max = maxDocumentCount).flatMap { existingDocumentCount ->
+                        anyValidLoanDocumentSet(size = existingDocumentCount)
+                    },
+                    anyInvalidUuid,
+                ) { randomDocuments, randomInvalidId ->
+                    val (existingDocuments, newDocument) = randomDocuments.documentList.breakOffLast()
+                    shouldThrow<ContractViolationException> {
+                        AppendLoanDocumentsContract(
+                            existingDocs = existingDocuments.toRecord(),
+                        ).appendDocuments(
+                            newDocs = LoanDocuments.newBuilder().also { inputBuilder ->
+                                inputBuilder.clearDocument()
+                                inputBuilder.addDocument(
+                                    newDocument.toBuilder().also { documentBuilder ->
+                                        documentBuilder.id = randomInvalidId
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Document must have valid ID"
+                    }
+                }
             }
         }
-        "given input documents which duplicate existing document checksums" xshould {
+        "given an input which attempts to silently change properties of an existing document" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(
+                    Arb.int(min = 2, max = maxDocumentCount).flatMap { documentCount ->
+                        anyValidLoanDocumentSet(size = documentCount)
+                    },
+                    anyUuidSet(size = 2).toPair(),
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                ) { randomDocuments, (oldId, newId), (oldUri, newUri), (oldContentType, newContentType), (oldDocumentType, newDocumentType) ->
+                    val (existingDocuments, newDocument) = randomDocuments.documentList.breakOffLast()
+                    shouldThrow<ContractViolationException> {
+                        AppendLoanDocumentsContract(
+                            existingDocs = existingDocuments.toRecord().toBuilder().also { recordBuilder ->
+                                (recordBuilder.documentCount - 1).let { indexOfDocumentToModify ->
+                                    recordBuilder.setDocument(
+                                        indexOfDocumentToModify,
+                                        newDocument.toBuilder().also { documentBuilder ->
+                                            documentBuilder.id = oldId
+                                            documentBuilder.uri = oldUri
+                                            documentBuilder.contentType = oldContentType
+                                            documentBuilder.documentType = oldDocumentType
+                                        }.build()
+                                    )
+                                }
+                            }.build(),
+                        ).appendDocuments(
+                            newDocs = LoanDocuments.newBuilder().also { inputBuilder ->
+                                inputBuilder.clearDocument()
+                                inputBuilder.addDocument(
+                                    newDocument.toBuilder().also { documentBuilder ->
+                                        documentBuilder.id = newId
+                                        documentBuilder.uri = newUri
+                                        documentBuilder.contentType = newContentType
+                                        documentBuilder.documentType = newDocumentType
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 4U
+                        listOf("ID", "URI", "content type", "document type").forEach { immutableField ->
+                            exception.message shouldContain
+                                "Cannot change $immutableField of existing document with checksum ${newDocument.checksum.checksum}"
+                        }
+                    }
+                }
             }
         }
-        "given input documents with duplicate checksums" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given an input which attempts to silently change properties of one or more existing documents" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given a valid input" xshould {
+        "given a valid input" should {
             "not throw an exception" {
-                // TODO: Implement
+                val documentCountRange = 2..(if (KotestConfig.runTestsExtended) 8 else 3)
+                checkAll(
+                    Arb.int(documentCountRange).flatMap { randomDocumentCount ->
+                        Arb.pair(
+                            anyValidLoanDocumentSet(size = randomDocumentCount),
+                            Arb.int(0..max(randomDocumentCount - 1, 1)),
+                        )
+                    }
+                ) { (randomDocuments, randomSplit) ->
+                    val (randomExistingDocuments, randomNewDocuments) = randomDocuments.documentList.let { randomDocumentSet ->
+                        randomDocumentSet.take(randomSplit) to randomDocumentSet.drop(randomSplit)
+                    }
+                    AppendLoanDocumentsContract(
+                        existingDocs = randomExistingDocuments.toRecord(),
+                    ).appendDocuments(
+                        newDocs = randomNewDocuments.toRecord()
+                    )
+                }
             }
         }
     }
-})
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/OverwriteServicingRightsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/OverwriteServicingRightsUnitTest.kt
@@ -1,40 +1,145 @@
 package io.provenance.scope.loan.contracts
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.Constructors.recordContractWithEmptyScope
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.PrimitiveArbs.anyBlankString
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 
 class OverwriteServicingRightsUnitTest : WordSpec({
     "A function initializing the servicing rights record" When {
-        "given an empty input" xshould {
+        "given an empty input" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                shouldThrow<ContractViolationException> {
+                    recordContractWithEmptyScope.recordServicingRights(ServicingRights.getDefaultInstance())
+                }.let { exception ->
+                    exception shouldHaveViolationCount 1U
+                    exception.message shouldContain "Servicing rights are not set"
+                }
             }
         }
-        "given an invalid input" xshould {
+        "given an input with an invalid servicer ID" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(anyInvalidUuid, anyNonEmptyString) { randomInvalidId, randomServicerName ->
+                    shouldThrow<ContractViolationException> {
+                        recordContractWithEmptyScope.recordServicingRights(
+                            ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                                servicingRightsBuilder.servicerId = randomInvalidId
+                                servicingRightsBuilder.servicerName = randomServicerName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Servicing rights must have valid servicer UUID"
+                    }
+                }
             }
         }
-        "given a valid input" xshould {
+        "given an input without a servicer name" should {
+            "throw an appropriate exception" {
+                checkAll(anyUuid, anyBlankString) { randomId, randomBlankString ->
+                    shouldThrow<ContractViolationException> {
+                        recordContractWithEmptyScope.recordServicingRights(
+                            ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                                servicingRightsBuilder.servicerId = randomId
+                                servicingRightsBuilder.servicerName = randomBlankString
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Servicing rights missing servicer name"
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(anyUuid, anyNonEmptyString) { randomId, randomServicerName ->
+                    recordContractWithEmptyScope.recordServicingRights(
+                        ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                            servicingRightsBuilder.servicerId = randomId
+                            servicingRightsBuilder.servicerName = randomServicerName
+                        }.build()
+                    ).let { newServicingRights ->
+                        newServicingRights.servicerId shouldBe randomId
+                        newServicingRights.servicerName shouldBe randomServicerName
+                    }
+                }
             }
         }
     }
     "A function overwriting the existing servicing rights record" When {
-        "given an empty input" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
+        UpdateServicingRightsContract().run {
+            "given an empty input" should {
+                "throw an appropriate exception" {
+                    shouldThrow<ContractViolationException> {
+                        updateServicingRights(ServicingRights.getDefaultInstance())
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Servicing rights are not set"
+                    }
+                }
             }
-        }
-        "given an invalid input" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
+            "given an input with an invalid servicer ID" should {
+                "throw an appropriate exception" {
+                    checkAll(anyInvalidUuid, anyNonEmptyString) { randomInvalidId, randomServicerName ->
+                        shouldThrow<ContractViolationException> {
+                            updateServicingRights(
+                                ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                                    servicingRightsBuilder.servicerId = randomInvalidId
+                                    servicingRightsBuilder.servicerName = randomServicerName
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "Servicing rights must have valid servicer UUID"
+                        }
+                    }
+                }
             }
-        }
-        "given a valid input" xshould {
-            "not throw an exception" {
-                // TODO: Implement
+            "given an input without a servicer name" should {
+                "throw an appropriate exception" {
+                    checkAll(anyUuid, anyBlankString) { randomId, randomBlankString ->
+                        shouldThrow<ContractViolationException> {
+                            updateServicingRights(
+                                ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                                    servicingRightsBuilder.servicerId = randomId
+                                    servicingRightsBuilder.servicerName = randomBlankString
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "Servicing rights missing servicer name"
+                        }
+                    }
+                }
+            }
+            "given a valid input" should {
+                "not throw an exception" {
+                    checkAll(anyUuid, anyNonEmptyString) { randomId, randomServicerName ->
+                        updateServicingRights(
+                            ServicingRights.newBuilder().also { servicingRightsBuilder ->
+                                servicingRightsBuilder.servicerId = randomId
+                                servicingRightsBuilder.servicerName = randomServicerName
+                            }.build()
+                        ).let { updatedServicingRights ->
+                            updatedServicingRights.servicerId shouldBe randomId
+                            updatedServicingRights.servicerName shouldBe randomServicerName
+                        }
+                    }
+                }
             }
         }
     }
-})
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RandomLoanGenerationExperiment.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RandomLoanGenerationExperiment.kt
@@ -1,0 +1,100 @@
+package io.provenance.scope.loan.contracts
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hubspot.jackson.datatype.protobuf.ProtobufModule
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.next
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidAsset
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENote
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidLoan
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidLoanDocumentSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingData
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingRights
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationRecord
+import tech.figure.loan.v1beta1.MISMOLoanMetadata
+import tech.figure.loan.v1beta1.Loan as FigureTechLoan
+
+@Ignored
+internal class RandomLoanGenerationExperiment : WordSpec({
+    /* Helpers */
+    val mapper = ObjectMapper().also { objectMapper ->
+        objectMapper.registerModule(ProtobufModule())
+        objectMapper.writerWithDefaultPrettyPrinter()
+    }
+    val randomSource = RandomSource.default()
+    /* JSON generators */
+    "KotestHelpers" should {
+        "be able to generate a random fully populated Figure Tech loan scope" {
+            anyValidLoan<FigureTechLoan>().next(randomSource).let { randomLoanPackage ->
+                println(
+                    mapper.writeValueAsString(
+                        mapOf(
+                            LoanScopeFacts.asset to randomLoanPackage.asset,
+                            LoanScopeFacts.eNote to randomLoanPackage.eNote,
+                            LoanScopeFacts.servicingRights to randomLoanPackage.servicingRights,
+                            LoanScopeFacts.servicingData to randomLoanPackage.servicingData,
+                            LoanScopeFacts.loanValidations to randomLoanPackage.loanValidations,
+                            LoanScopeFacts.documents to randomLoanPackage.documents,
+                        )
+                    )
+                )
+            }
+        }
+        "be able to generate a random fully populated MISMO loan scope" {
+            anyValidLoan<MISMOLoanMetadata>().next(randomSource).let { randomLoanPackage ->
+                println(
+                    mapper.writeValueAsString(
+                        mapOf(
+                            LoanScopeFacts.asset to randomLoanPackage.asset,
+                            LoanScopeFacts.eNote to randomLoanPackage.eNote,
+                            LoanScopeFacts.servicingRights to randomLoanPackage.servicingRights,
+                            LoanScopeFacts.servicingData to randomLoanPackage.servicingData,
+                            LoanScopeFacts.loanValidations to randomLoanPackage.loanValidations,
+                            LoanScopeFacts.documents to randomLoanPackage.documents,
+                        )
+                    )
+                )
+            }
+        }
+        "!be able to generate a random asset for a Figure Tech loan" {
+            // TODO: Convert to JsonNode and alter loan value JsonNode to unpacked version
+            println(
+                mapper.writeValueAsString(anyValidAsset<FigureTechLoan>().next(randomSource))
+            )
+        }
+        "!be able to generate a random asset for a MISMO loan" {
+            // TODO: Convert to JsonNode and alter loan value JsonNode to unpacked version
+            println(
+                mapper.writeValueAsString(anyValidAsset<MISMOLoanMetadata>().next(randomSource))
+            )
+        }
+        "be able to generate a random eNote" {
+            println(
+                mapper.writeValueAsString(anyValidENote().next(randomSource))
+            )
+        }
+        "be able to generate random servicing rights" {
+            println(
+                mapper.writeValueAsString(anyValidServicingRights.next(randomSource))
+            )
+        }
+        "be able to generate random servicing data" {
+            println(
+                mapper.writeValueAsString(anyValidServicingData(loanStateCount = 4).next(randomSource))
+            )
+        }
+        "be able to generate a random validation record" {
+            println(
+                mapper.writeValueAsString(anyValidValidationRecord(iterationCount = 4).next(randomSource))
+            )
+        }
+        "be able to generate random loan documents" {
+            println(
+                mapper.writeValueAsString(anyValidLoanDocumentSet(size = 4).next(randomSource))
+            )
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
@@ -1,50 +1,229 @@
 package io.provenance.scope.loan.contracts
 
+import io.dartinc.registry.v1beta1.ENote
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.localDate
+import io.kotest.property.arbitrary.map
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyPastNonEpochDate
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentMetadata
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENoteController
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.loanStateSet
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.utility.ContractViolationException
+import io.provenance.scope.loan.utility.isSet
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
+import tech.figure.util.v1beta1.Date
+import java.time.LocalDate
 
 class RecordENoteContractUnitTest : WordSpec({
-    "recordENote" When {
-        "given an empty input" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
+    /**
+     * This test class should only need to test for an empty scope as long as all functions of RecordENoteContract use @SkipIfRecordExists
+     */
+    RecordENoteContract(
+        existingENote = ENote.getDefaultInstance(),
+        existingServicingData = ServicingData.getDefaultInstance(),
+    ).run {
+        "recordENote for an empty scope" When {
+            "given an empty input" should {
+                "throw an appropriate exception" {
+                    shouldThrow<ContractViolationException> {
+                        recordENote(ENote.getDefaultInstance())
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote is not set"
+                    }
+                }
+            }
+            "given an input without a controller" should {
+                "throw an appropriate exception" {
+                    checkAll(anyValidDocumentMetadata, anyPastNonEpochDate, anyNonEmptyString) { randomDocument, randomSignedDate, randomVaultName ->
+                        shouldThrow<ContractViolationException> {
+                            recordENote(
+                                ENote.newBuilder().also { eNoteBuilder ->
+                                    eNoteBuilder.clearController()
+                                    eNoteBuilder.eNote = randomDocument
+                                    eNoteBuilder.signedDate = randomSignedDate
+                                    eNoteBuilder.vaultName = randomVaultName
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "Controller is not set"
+                        }
+                    }
+                }
+            }
+            "given an input without an eNote" should {
+                "throw an appropriate exception" {
+                    checkAll(anyValidENoteController, anyPastNonEpochDate, anyNonEmptyString) { randomController, randomSignedDate, randomVaultName ->
+                        shouldThrow<ContractViolationException> {
+                            recordENote(
+                                ENote.newBuilder().also { eNoteBuilder ->
+                                    eNoteBuilder.clearENote()
+                                    eNoteBuilder.controller = randomController
+                                    eNoteBuilder.signedDate = randomSignedDate
+                                    eNoteBuilder.vaultName = randomVaultName
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "eNote document is not set"
+                        }
+                    }
+                }
+            }
+            "given an input without a signed date" should {
+                "throw an appropriate exception" {
+                    checkAll(anyValidENoteController, anyValidDocumentMetadata, anyNonEmptyString) { randomController, randomENote, randomVaultName ->
+                        shouldThrow<ContractViolationException> {
+                            recordENote(
+                                ENote.newBuilder().also { eNoteBuilder ->
+                                    eNoteBuilder.clearSignedDate()
+                                    eNoteBuilder.controller = randomController
+                                    eNoteBuilder.eNote = randomENote
+                                    eNoteBuilder.vaultName = randomVaultName
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "eNote must have valid signed date"
+                        }
+                    }
+                }
+            }
+            "given an input with a signed date in the future" should {
+                "throw an appropriate exception" {
+                    checkAll(
+                        anyValidENoteController,
+                        anyValidDocumentMetadata,
+                        anyNonEmptyString,
+                        Arb.localDate(
+                            minDate = LocalDate.now().plusDays(1L),
+                        ).map { javaLocalDate ->
+                            Date.newBuilder().also { dateBuilder ->
+                                dateBuilder.value = javaLocalDate.toString()
+                            }.build()
+                        }
+                    ) { randomController, randomENote, randomVaultName, randomInvalidSignedDate ->
+                        shouldThrow<ContractViolationException> {
+                            recordENote(
+                                ENote.newBuilder().also { eNoteBuilder ->
+                                    eNoteBuilder.controller = randomController
+                                    eNoteBuilder.eNote = randomENote
+                                    eNoteBuilder.vaultName = randomVaultName
+                                    eNoteBuilder.signedDate = randomInvalidSignedDate
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "eNote must have valid signed date"
+                        }
+                    }
+                }
+            }
+            "given a valid input" should {
+                "not throw an exception" {
+                    checkAll(
+                        anyValidDocumentMetadata,
+                        anyValidENoteController,
+                        anyPastNonEpochDate,
+                        anyNonEmptyString,
+                    ) { randomDocument, randomController, randomSignedDate, randomVaultName ->
+                        recordENote(
+                            ENote.newBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = randomDocument
+                                eNoteBuilder.controller = randomController
+                                eNoteBuilder.signedDate = randomSignedDate
+                                eNoteBuilder.vaultName = randomVaultName
+                            }.build()
+                        ).let { newENote ->
+                            newENote.eNote.isSet() shouldBe true
+                            newENote.controller.isSet() shouldBe true
+                            newENote.signedDate.isSet() shouldBe true
+                            newENote.vaultName.isNotBlank() shouldBe true
+                        }
+                    }
+                }
             }
         }
-        "given an invalid input to an empty scope" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
+        "recordServicingData for an empty scope" When {
+            "given an empty input" should {
+                "throw an appropriate exception" {
+                    shouldThrow<ContractViolationException> {
+                        recordServicingData(ServicingData.getDefaultInstance())
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Servicing data is not set"
+                    }
+                }
             }
-        }
-        "given a valid input" xshould {
-            "not throw an exception" {
-                // TODO: Implement
+            "given an input with an invalid document" should {
+                "throw an appropriate exception" {
+                    checkAll(
+                        loanStateSet(size = 1),
+                        anyValidDocumentMetadata,
+                        anyValidDocumentMetadata,
+                        anyInvalidUuid,
+                    ) { randomLoanState, randomFirstValidDocument, randomSecondDocument, randomInvalidId ->
+                        shouldThrow<ContractViolationException> {
+                            recordServicingData(
+                                ServicingData.newBuilder().also { servicingDataBuilder ->
+                                    servicingDataBuilder.addAllLoanState(randomLoanState)
+                                    servicingDataBuilder.clearDocMeta()
+                                    servicingDataBuilder.addDocMeta(randomFirstValidDocument)
+                                    servicingDataBuilder.addDocMeta(
+                                        randomSecondDocument.toBuilder().also { invalidDocumentBuilder ->
+                                            invalidDocumentBuilder.id = randomInvalidId
+                                        }.build()
+                                    )
+                                }.build()
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1U
+                            exception.message shouldContain "Document must have valid ID"
+                        }
+                    }
+                }
+            }
+            "given a valid input" should {
+                "not throw an exception" {
+                    checkAll(
+                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 100 else 10).flatMap { randomLoanDocumentCount ->
+                            anyValidDocumentSet(size = randomLoanDocumentCount, slippage = 70)
+                        },
+                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 100 else 10).flatMap { randomLoanStateCount ->
+                            loanStateSet(size = randomLoanStateCount, slippage = 70)
+                        },
+                    ) { randomServicingDocuments, randomLoanStates ->
+                        recordServicingData(
+                            ServicingData.newBuilder().also { servicingDataBuilder ->
+                                servicingDataBuilder.clearDocMeta()
+                                servicingDataBuilder.addAllDocMeta(randomServicingDocuments)
+                                servicingDataBuilder.clearLoanState()
+                                servicingDataBuilder.addAllLoanState(randomLoanStates)
+                            }.build()
+                        ).let { newServicingData ->
+                            newServicingData.docMetaCount shouldBeExactly randomServicingDocuments.size
+                            newServicingData.loanStateCount shouldBeExactly randomLoanStates.size
+                        }
+                    }
+                }
             }
         }
     }
-    "recordServicingData" When {
-        "given an empty input" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given an invalid input to an empty scope" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given an invalid input to update the existing servicing data record" xshould {
-            "throw an appropriate exception" {
-                // TODO: Implement
-            }
-        }
-        "given a valid input to an empty scope" xshould {
-            "not throw an exception" {
-                // TODO: Implement
-            }
-        }
-        "given a valid input to update the existing servicing data record" xshould {
-            "not throw an exception" {
-                // TODO: Implement
-            }
-        }
-    }
-})
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
@@ -1,65 +1,120 @@
 package io.provenance.scope.loan.contracts
 
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.long
 import io.kotest.property.checkAll
 import io.provenance.scope.loan.test.Constructors.requestContractWithEmptyExistingRecord
-import io.provenance.scope.loan.test.Constructors.validRequest
-import io.provenance.scope.loan.test.LoanPackageArbs.anyInvalidUuid
-import io.provenance.scope.loan.test.LoanPackageArbs.anyNonEmptyString
-import io.provenance.scope.loan.test.LoanPackageArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyFutureTimestamp
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationRequest
+import io.provenance.scope.loan.test.shouldHaveViolationCount
 import io.provenance.scope.loan.utility.ContractViolationException
 import tech.figure.validation.v1beta1.ValidationRequest
-import kotlin.random.Random
 
-class RecordLoanValidationRequestUnitTest : WordSpec({ // TODO: Refactor usage of Random context
+class RecordLoanValidationRequestUnitTest : WordSpec({
     "recordLoanValidationRequest" When {
         "given an empty input to an empty scope" should {
             "throw an appropriate exception" {
-                ValidationRequest.getDefaultInstance().let { emptyResultSubmission ->
+                shouldThrow<ContractViolationException> {
+                    requestContractWithEmptyExistingRecord.apply {
+                        recordLoanValidationRequest(ValidationRequest.getDefaultInstance())
+                    }
+                }.let { exception ->
+                    exception shouldHaveViolationCount 1U
+                    exception.message shouldContain "Request is not set"
+                }
+            }
+        }
+        "given an input to an empty scope with an invalid ID" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidValidationRequest, anyInvalidUuid) { randomRequest, randomInvalidId ->
                     shouldThrow<ContractViolationException> {
-                        requestContractWithEmptyExistingRecord.apply {
-                            recordLoanValidationRequest(emptyResultSubmission)
-                        }
+                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                            submission = randomRequest.toBuilder().also { requestBuilder ->
+                                requestBuilder.requestId = randomInvalidId
+                            }.build()
+                        )
                     }.let { exception ->
-                        exception.message shouldContain "Request is not set"
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Request must have valid ID"
                     }
                 }
             }
         }
-        "given an invalid input to an empty scope" should {
+        "given an input to an empty scope with an effective time in the future" should {
             "throw an appropriate exception" {
-                checkAll(anyInvalidUuid) { randomInvalidId ->
+                checkAll(anyValidValidationRequest, anyFutureTimestamp) { randomRequest, randomInvalidTimestamp ->
                     shouldThrow<ContractViolationException> {
-                        requestContractWithEmptyExistingRecord.apply {
-                            recordLoanValidationRequest(
-                                submission = ValidationRequest.newBuilder().also { requestBuilder ->
-                                    requestBuilder.requestId = randomInvalidId
-                                }.build()
-                            )
-                        }
+                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                            submission = randomRequest.toBuilder().also { requestBuilder ->
+                                requestBuilder.effectiveTime = randomInvalidTimestamp
+                            }.build()
+                        )
                     }.let { exception ->
-                        exception.message shouldContain "Request must have valid ID"
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Request must have valid effective time"
+                    }
+                }
+            }
+        }
+        "given an input to an empty scope with an invalid block height" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidValidationRequest, Arb.long(max = -1L)) { randomRequest, randomInvalidBlockHeight ->
+                    shouldThrow<ContractViolationException> {
+                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                            submission = randomRequest.toBuilder().also { requestBuilder ->
+                                requestBuilder.blockHeight = randomInvalidBlockHeight
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Request must have valid block height"
+                    }
+                }
+            }
+        }
+        "given an input to an empty scope without a validator name" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidValidationRequest) { randomRequest ->
+                    shouldThrow<ContractViolationException> {
+                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                            submission = randomRequest.toBuilder().also { requestBuilder ->
+                                requestBuilder.clearValidatorName()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Request is missing validator name"
+                    }
+                }
+            }
+        }
+        "given an input to an empty scope without a requester name" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidValidationRequest) { randomRequest ->
+                    shouldThrow<ContractViolationException> {
+                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                            submission = randomRequest.toBuilder().also { requestBuilder ->
+                                requestBuilder.clearRequesterName()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Request is missing requester name"
                     }
                 }
             }
         }
         "given a valid input" should {
             "not throw an exception" {
-                checkAll(anyUuid, anyNonEmptyString) { randomUuid, randomValidator ->
-                    shouldNotThrow<ContractViolationException> {
-                        requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
-                            Random.run {
-                                validRequest(
-                                    requestID = randomUuid,
-                                    validatorName = randomValidator,
-                                )
-                            }
-                        )
-                    }
+                checkAll(anyValidValidationRequest) { randomRequest ->
+                    requestContractWithEmptyExistingRecord.recordLoanValidationRequest(
+                        submission = randomRequest
+                    )
                 }
             }
         }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
@@ -1,28 +1,238 @@
 package io.provenance.scope.loan.contracts
 
+import io.dartinc.registry.v1beta1.ENote
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyChecksumSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyPastNonEpochDate
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentMetadata
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENote
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENoteController
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidLoanDocumentSet
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.test.toPair
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.util.v1beta1.DocumentMetadata
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 
 class UpdateENoteContractUnitTest : WordSpec({
     "updateENote" When {
-        "given an empty input" xshould {
+        "given an empty input" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(anyValidENote()) { randomExistingENote ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote,
+                        ).updateENote(
+                            DocumentMetadata.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote document is not set"
+                    }
+                }
             }
         }
-        "given an invalid input" xshould {
+        "given an input with an invalid ID" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(
+                    anyValidENote(),
+                    anyValidDocumentMetadata,
+                    anyChecksumSet(size = 2).toPair(),
+                    anyInvalidUuid,
+                ) { randomExistingENote, randomNewENote, (randomExistingChecksum, randomNewChecksum), randomInvalidId ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = eNoteBuilder.eNote.toBuilder().also { documentBuilder ->
+                                    documentBuilder.checksum = randomExistingChecksum
+                                }.build()
+                            }.build(),
+                        ).updateENote(
+                            randomNewENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.id = randomInvalidId
+                                eNoteBuilder.checksum = randomNewChecksum
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote must have valid ID"
+                    }
+                }
             }
         }
-        "given an input which attempts to silently change properties of the existing eNote" xshould {
+        "given an input without a URI" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(
+                    anyValidENote(),
+                    anyValidDocumentMetadata,
+                    anyChecksumSet(size = 2).toPair(),
+                ) { randomExistingENote, randomNewENote, (randomExistingChecksum, randomNewChecksum) ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = eNoteBuilder.eNote.toBuilder().also { documentBuilder ->
+                                    documentBuilder.checksum = randomExistingChecksum
+                                }.build()
+                            }.build(),
+                        ).updateENote(
+                            randomNewENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.checksum = randomNewChecksum
+                                eNoteBuilder.clearUri()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote is missing URI"
+                    }
+                }
             }
         }
-        "given a valid input" xshould {
+        "given an input without a content type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidDocumentMetadata,
+                    anyChecksumSet(size = 2).toPair(),
+                ) { randomExistingENote, randomNewENote, (randomExistingChecksum, randomNewChecksum) ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = eNoteBuilder.eNote.toBuilder().also { documentBuilder ->
+                                    documentBuilder.checksum = randomExistingChecksum
+                                }.build()
+                            }.build(),
+                        ).updateENote(
+                            randomNewENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.checksum = randomNewChecksum
+                                eNoteBuilder.clearContentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote is missing content type"
+                    }
+                }
+            }
+        }
+        "given an input without a document type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidDocumentMetadata,
+                    anyChecksumSet(size = 2).toPair(),
+                ) { randomExistingENote, randomNewENote, (randomExistingChecksum, randomNewChecksum) ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = eNoteBuilder.eNote.toBuilder().also { documentBuilder ->
+                                    documentBuilder.checksum = randomExistingChecksum
+                                }.build()
+                            }.build(),
+                        ).updateENote(
+                            randomNewENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.checksum = randomNewChecksum
+                                eNoteBuilder.clearDocumentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote is missing document type"
+                    }
+                }
+            }
+        }
+        "given an input without a valid checksum" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomId, randomUri, randomContentType, randomDocumentType, randomChecksumAlgorithm ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = randomExistingENote,
+                        ).updateENote(
+                            DocumentMetadata.newBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.id = randomId
+                                eNoteBuilder.uri = randomUri
+                                eNoteBuilder.contentType = randomContentType
+                                eNoteBuilder.documentType = randomDocumentType
+                                eNoteBuilder.checksum = FigureTechChecksum.newBuilder().also { checksumBuilder ->
+                                    checksumBuilder.clearChecksum()
+                                    checksumBuilder.algorithm = randomChecksumAlgorithm
+                                }.build()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "eNote is missing checksum"
+                    }
+                }
+            }
+        }
+        "given an input which attempts to silently change the URI of the existing eNote" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENoteController,
+                    anyPastNonEpochDate,
+                    anyNonEmptyString,
+                    anyValidDocumentMetadata,
+                ) { randomController, randomSignedDate, randomVaultName, randomENote ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteContract(
+                            existingENote = ENote.newBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.eNote = randomENote
+                                eNoteBuilder.controller = randomController
+                                eNoteBuilder.signedDate = randomSignedDate
+                                eNoteBuilder.vaultName = randomVaultName
+                            }.build(),
+                        ).updateENote(
+                            newENote = randomENote.toBuilder().also { eNoteBuilder ->
+                                eNoteBuilder.uri = "someNewDirectory/" + eNoteBuilder.uri
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Cannot change URI of existing document with checksum ${randomENote.checksum.checksum}"
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(
+                    anyValidENoteController,
+                    anyPastNonEpochDate,
+                    anyNonEmptyString,
+                    anyValidLoanDocumentSet(size = 2).toPair { record -> record.documentList },
+                ) { randomController, randomSignedDate, randomVaultName, (randomExistingENote, randomNewENote) ->
+                    UpdateENoteContract(
+                        existingENote = ENote.newBuilder().also { eNoteBuilder ->
+                            eNoteBuilder.eNote = randomExistingENote
+                            eNoteBuilder.controller = randomController
+                            eNoteBuilder.signedDate = randomSignedDate
+                            eNoteBuilder.vaultName = randomVaultName
+                        }.build(),
+                    ).updateENote(
+                        newENote = randomNewENote
+                    ).let { newENote ->
+                        newENote.eNote shouldBe randomNewENote
+                    }
+                }
             }
         }
     }
-})
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteControllerUnitTest.kt
@@ -1,23 +1,91 @@
 package io.provenance.scope.loan.contracts
 
+import io.dartinc.registry.v1beta1.Controller
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENote
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENoteController
+import io.provenance.scope.loan.test.PrimitiveArbs.anyBlankString
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.utility.ContractViolationException
 
 class UpdateENoteControllerUnitTest : WordSpec({
     "updateENoteController" When {
-        "given an empty input" xshould {
+        "given an empty input" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(anyValidENote()) { randomExistingENote ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteControllerContract(
+                            existingENote = randomExistingENote,
+                        ).updateENoteController(
+                            Controller.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Controller is not set"
+                    }
+                }
             }
         }
-        "given an invalid input" xshould {
+        "given an input with an invalid controller ID" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(anyValidENote(), anyInvalidUuid, anyNonEmptyString) { randomExistingENote, randomInvalidId, randomControllerName ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteControllerContract(
+                            existingENote = randomExistingENote,
+                        ).updateENoteController(
+                            Controller.newBuilder().also { controllerBuilder ->
+                                controllerBuilder.controllerUuid = randomInvalidId
+                                controllerBuilder.controllerName = randomControllerName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Controller must have valid UUID"
+                    }
+                }
             }
         }
-        "given a valid input" xshould {
+        "given an input without a controller name" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidENote(), anyUuid, anyBlankString) { randomExistingENote, randomControllerId, randomBlankString ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateENoteControllerContract(
+                            existingENote = randomExistingENote,
+                        ).updateENoteController(
+                            Controller.newBuilder().also { controllerBuilder ->
+                                controllerBuilder.controllerUuid = randomControllerId
+                                controllerBuilder.controllerName = randomBlankString
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1U
+                        exception.message shouldContain "Controller is missing name"
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(anyValidENote(), anyValidENoteController) { randomExistingENote, randomNewController ->
+                    UpdateENoteControllerContract(
+                        existingENote = randomExistingENote,
+                    ).updateENoteController(
+                        newController = randomNewController
+                    ).let { updatedENote ->
+                        updatedENote.controller shouldBe randomNewController
+                    }
+                }
             }
         }
     }
-})
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -5,18 +5,10 @@ import io.provenance.scope.loan.contracts.AppendLoanStatesContract
 import io.provenance.scope.loan.contracts.RecordLoanContract
 import io.provenance.scope.loan.contracts.RecordLoanValidationRequestContract
 import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
-import io.provenance.scope.util.toProtoTimestamp
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.validation.v1beta1.LoanValidation
-import tech.figure.validation.v1beta1.ValidationItem
-import tech.figure.validation.v1beta1.ValidationIteration
-import tech.figure.validation.v1beta1.ValidationRequest
-import tech.figure.validation.v1beta1.ValidationResponse
-import tech.figure.validation.v1beta1.ValidationResults
-import java.time.OffsetDateTime
-import kotlin.random.Random
 import java.util.UUID as JavaUUID
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
@@ -47,51 +39,4 @@ object Constructors {
         get() = RecordLoanValidationRequestContract(
             LoanValidation.getDefaultInstance()
         )
-    context(Random)
-    fun validRequest(
-        requestID: FigureTechUUID,
-        requesterName: String = "someArbitraryRequesterName",
-        validatorName: String = "yetAnotherRandomProviderName",
-    ): ValidationRequest = ValidationRequest.newBuilder().also { requestBuilder ->
-        requestBuilder.requestId = requestID
-        requestBuilder.ruleSetId = randomProtoUuid
-        requestBuilder.blockHeight = nextLong(0, Long.MAX_VALUE)
-        requestBuilder.effectiveTime = OffsetDateTime.now().toProtoTimestamp()
-        requestBuilder.requesterName = requesterName
-        requestBuilder.validatorName = validatorName
-    }.build()
-    context(Random)
-    fun resultsContractWithSingleRequest(
-        requestID: FigureTechUUID,
-        validatorName: String = "anotherRandomProviderName",
-    ) = RecordLoanValidationResultsContract(
-        LoanValidation.newBuilder().also { validationRecordBuilder ->
-            validationRecordBuilder.clearIteration()
-            validationRecordBuilder.addIteration(
-                ValidationIteration.newBuilder().also { iterationBuilder ->
-                    iterationBuilder.request = validRequest(
-                        requestID = requestID,
-                        validatorName = validatorName,
-                    )
-                }.build()
-            )
-        }.build()
-    )
-    fun validResultSubmission(
-        iterationRequestID: FigureTechUUID = randomProtoUuid,
-        resultSetID: FigureTechUUID = randomProtoUuid,
-        resultSetProvider: String = "arbitraryProviderName",
-    ): ValidationResponse = ValidationResponse.newBuilder().also { responseBuilder ->
-        responseBuilder.requestId = iterationRequestID
-        responseBuilder.results = ValidationResults.newBuilder().also { resultsBuilder ->
-            resultsBuilder.resultSetUuid = resultSetID
-            resultsBuilder.resultSetProvider = resultSetProvider
-            resultsBuilder.resultSetEffectiveTime = OffsetDateTime.now().toProtoTimestamp()
-            resultsBuilder.addValidationItems(
-                ValidationItem.newBuilder().also { validationItemBuilder ->
-                    validationItemBuilder.description = "Yep stuff passed I guess"
-                }.build()
-            )
-        }.build()
-    }.build()
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -1,12 +1,16 @@
 package io.provenance.scope.loan.test
 
 import com.google.protobuf.InvalidProtocolBufferException
+import com.google.protobuf.Message
 import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Timestamps
+import io.dartinc.registry.v1beta1.Controller
+import io.dartinc.registry.v1beta1.ENote
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.beInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.Codepoint
@@ -18,34 +22,59 @@ import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.filterNot
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.localDate
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.arbitrary.set
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.uInt
 import io.kotest.property.arbitrary.uuid
+import io.provenance.scope.loan.LoanPackage
+import io.provenance.scope.loan.LoanScopeProperties
 import io.provenance.scope.loan.utility.ContractEnforcement
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.ContractViolationMap
+import io.provenance.scope.loan.utility.IllegalContractStateException
 import io.provenance.scope.loan.utility.UnexpectedContractStateException
+import tech.figure.asset.v1beta1.Asset
+import tech.figure.loan.v1beta1.LoanDocuments
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
+import tech.figure.proto.util.toProtoAny
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
+import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
 import tech.figure.util.v1beta1.DocumentMetadata
+import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta1.ValidationItem
+import tech.figure.validation.v1beta1.ValidationIteration
+import tech.figure.validation.v1beta1.ValidationOutcome
+import tech.figure.validation.v1beta1.ValidationRequest
+import tech.figure.validation.v1beta1.ValidationResponse
+import tech.figure.validation.v1beta1.ValidationResults
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.LocalDate as JavaLocalDate
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
 /**
- * Generators of [Arb]itrary instances.
+ * Generators of [Arb]itrary instances of classes not defined in the metadata asset model, like primitives or Java classes.
  */
-internal object LoanPackageArbs {
+internal object PrimitiveArbs {
     /* Primitives */
     val anyNonEmptyString: Arb<String> = Arb.string().filter { it.isNotBlank() }
+    val anyBlankString: Arb<String> = Arb.string().filter { it.isBlank() }
     val anyNonUuidString: Arb<String> = Arb.string().filterNot { it.length == 36 }
-    val anyValidUli: Arb<String> = Arb.string(minSize = 23, maxSize = 45, codepoints = Codepoint.alphanumeric()) // TODO: Refine if at all possible
-    val anyNonUliString: Arb<String> = Arb.string().filterNot { it.length in 23..45 } // TODO: Should be complement of anyUli
+    val anyValidUli: Arb<String> = Arb.string(minSize = 23, maxSize = 45, codepoints = Codepoint.alphanumeric())
+    val anyNonUliString: Arb<String> = Arb.string().filterNot { it.length in 23..45 }
+    /* Java classes */
+    val anyZoneOffset: Arb<ZoneOffset> = Arb.int(min = ZoneOffset.MIN.totalSeconds, max = ZoneOffset.MAX.totalSeconds).map { offsetInSeconds ->
+        ZoneOffset.ofTotalSeconds(offsetInSeconds)
+    }
     /* Contract requirements */
     val anyContractEnforcement: Arb<ContractEnforcement> = Arb.bind(
         Arb.boolean(),
@@ -59,28 +88,60 @@ internal object LoanPackageArbs {
     ) { violationList, countList ->
         violationList.zip(countList).toMap().toMutableMap()
     }
+}
+
+/**
+ * Generators of [Arb]itrary instances of classes defined in the metadata asset model.
+ */
+internal object MetadataAssetModelArbs {
     /* Protobufs */
     val anyValidChecksum: Arb<FigureTechChecksum> = Arb.bind(
-        anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
         Arb.string(),
-    ) { checksum, algorithmType ->
+    ) { checksum, algorithm ->
         FigureTechChecksum.newBuilder().also { checksumBuilder ->
             checksumBuilder.checksum = checksum
-            checksumBuilder.algorithm = algorithmType
+            checksumBuilder.algorithm = algorithm
         }.build()
     }
+    fun anyChecksumSet(size: Int, slippage: Int = 10): Arb<List<FigureTechChecksum>> =
+        /** Since we need each checksum to be unique, we must fix the set size & construct the arbs from scratch with primitives */
+        Arb.bind(
+            Arb.set(gen = PrimitiveArbs.anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
+            Arb.list(gen = Arb.string(), range = size..size),
+        ) { checksums, algorithms ->
+            checksums.indices.map { i ->
+                FigureTechChecksum.newBuilder().also { checksumBuilder ->
+                    checksumBuilder.checksum = checksums[i]
+                    checksumBuilder.algorithm = algorithms[i]
+                }.build()
+            }
+        }
     val anyUuid: Arb<FigureTechUUID> = Arb.uuid(UUIDVersion.V4).map { arbUuidV4 ->
         FigureTechUUID.newBuilder().apply {
             value = arbUuidV4.toString()
         }.build()
     }
+    fun anyUuidSet(size: Int, slippage: Int = 10): Arb<List<FigureTechUUID>> =
+        Arb.set(gen = Arb.uuid(UUIDVersion.V4), size = size, slippage = slippage).map { set ->
+            set.toList().map { uuid ->
+                FigureTechUUID.newBuilder().apply {
+                    value = uuid.toString()
+                }.build()
+            }
+        }
+    val anyInvalidUuid: Arb<FigureTechUUID> = PrimitiveArbs.anyNonUuidString.map { arbInvalidUuid ->
+        FigureTechUUID.newBuilder().apply {
+            value = arbInvalidUuid
+        }.build()
+    }
     val anyValidDocumentMetadata: Arb<DocumentMetadata> = Arb.bind(
         anyUuid,
         anyValidChecksum,
-        anyNonEmptyString,
-        anyNonEmptyString,
-        anyNonEmptyString,
-        anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
     ) { id, checksumValue, contentType, documentType, filename, uri ->
         DocumentMetadata.newBuilder().also { documentBuilder ->
             documentBuilder.id = id
@@ -91,20 +152,30 @@ internal object LoanPackageArbs {
             documentBuilder.uri = uri
         }.build()
     }
-    val anyInvalidUuid: Arb<FigureTechUUID> = anyNonUuidString.map { arbInvalidUuid ->
-        FigureTechUUID.newBuilder().apply {
-            value = arbInvalidUuid
+    val anyPastNonEpochDate: Arb<FigureTechDate> = Arb.localDate(
+        maxDate = JavaLocalDate.now(),
+    ).map { javaLocalDate ->
+        FigureTechDate.newBuilder().also { dateBuilder ->
+            dateBuilder.value = javaLocalDate.toString()
         }.build()
+    }.filterNot { date ->
+        date.value === JavaLocalDate.of(1970, 1, 1).toString()
     }
-    val anyValidTimestamp: Arb<Timestamp> = anyTimestampComponents.map { (seconds, nanoSeconds) ->
-        Timestamp.newBuilder().also { timestampBuilder ->
-            timestampBuilder.seconds = seconds
-            timestampBuilder.nanos = nanoSeconds
+    val anyValidTimestamp: Arb<Timestamp> = anyTimestampComponents.toTimestamp()
+    val anyPastNonEpochTimestamp: Arb<Timestamp> = anyPastNonEpochTimestampComponents.toTimestamp()
+    val anyFutureTimestamp: Arb<Timestamp> = anyFutureTimestampComponents.toTimestamp()
+    val anyValidENoteController: Arb<Controller> = Arb.bind(
+        anyUuid,
+        PrimitiveArbs.anyNonEmptyString,
+    ) { controllerId, controllerName ->
+        Controller.newBuilder().also { controllerBuilder ->
+            controllerBuilder.controllerUuid = controllerId
+            controllerBuilder.controllerName = controllerName
         }.build()
     }
     val anyValidFigureTechLoan: Arb<FigureTechLoan> = Arb.bind(
         anyUuid,
-        anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
     ) { loanId, originatorName ->
         FigureTechLoan.newBuilder().also { loanBuilder ->
             loanBuilder.id = loanId
@@ -112,7 +183,7 @@ internal object LoanPackageArbs {
         }.build()
     }
     val anyValidMismoLoan: Arb<MISMOLoanMetadata> = Arb.bind(
-        anyValidUli,
+        PrimitiveArbs.anyValidUli,
         anyValidDocumentMetadata,
     ) { uli, document ->
         MISMOLoanMetadata.newBuilder().also { loanBuilder ->
@@ -123,8 +194,8 @@ internal object LoanPackageArbs {
     val anyValidLoanState: Arb<LoanStateMetadata> = Arb.bind(
         anyUuid,
         anyValidChecksum,
-        anyValidTimestamp,
-        anyNonEmptyString,
+        anyPastNonEpochTimestamp,
+        PrimitiveArbs.anyNonEmptyString,
     ) { uuid, checksum, effectiveTime, uri ->
         LoanStateMetadata.newBuilder().also { loanStateBuilder ->
             loanStateBuilder.id = uuid
@@ -134,18 +205,16 @@ internal object LoanPackageArbs {
         }.build()
     }
     fun loanStateSet(size: Int, slippage: Int = 10): Arb<List<LoanStateMetadata>> =
-        /** Since we need each *property* to be unique, we must fix the set size & construct the arbs from scratch with primitives */
+        /** Since we need some properties to be unique, we must fix the set size & construct the arbs from scratch with primitives */
         Arb.bind(
-            Arb.set(gen = Arb.uuid(UUIDVersion.V4), size = size, slippage = slippage).map { it.toList() },
-            Arb.set(gen = anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
-            Arb.set(gen = anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
+            anyUuidSet(size = size, slippage = slippage),
+            Arb.set(gen = PrimitiveArbs.anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
+            Arb.set(gen = PrimitiveArbs.anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
             Arb.set(gen = anyPastNonEpochTimestampComponents, size = size, slippage = slippage).map { it.toList() },
-        ) { randomIds, randomChecksums, randomUris, randomTimestamps ->
-            randomIds.indices.map { i ->
+        ) { loanIds, randomChecksums, randomUris, randomTimestamps ->
+            loanIds.indices.map { i ->
                 LoanStateMetadata.newBuilder().also { loanStateBuilder ->
-                    loanStateBuilder.id = FigureTechUUID.newBuilder().also { uuidBuilder ->
-                        uuidBuilder.value = randomIds[i].toString()
-                    }.build()
+                    loanStateBuilder.id = loanIds[i]
                     loanStateBuilder.checksum = FigureTechChecksum.newBuilder().also { checksumBuilder ->
                         checksumBuilder.checksum = randomChecksums[i]
                     }.build()
@@ -157,6 +226,232 @@ internal object LoanPackageArbs {
                 }.build()
             }
         }
+    fun anyValidDocumentSet(size: Int, slippage: Int = 10): Arb<List<DocumentMetadata>> =
+        /** Since we need some properties to be unique, we must fix the set size & construct the arbs from scratch with primitives */
+        Arb.bind(
+            anyUuidSet(size = size, slippage = slippage),
+            Arb.set(gen = PrimitiveArbs.anyNonEmptyString, size = size, slippage = slippage).map { it.toList() },
+            Arb.list(gen = PrimitiveArbs.anyNonEmptyString, range = size..size),
+            Arb.list(gen = PrimitiveArbs.anyNonEmptyString, range = size..size),
+            Arb.list(gen = PrimitiveArbs.anyNonEmptyString, range = size..size),
+            anyChecksumSet(size = size, slippage = slippage),
+        ) { documentIds, uris, fileNames, contentTypes, documentTypes, checksums ->
+            documentIds.indices.map { i ->
+                DocumentMetadata.newBuilder().also { documentBuilder ->
+                    documentBuilder.id = documentIds[i]
+                    documentBuilder.uri = uris[i]
+                    documentBuilder.fileName = fileNames[i]
+                    documentBuilder.contentType = contentTypes[i]
+                    documentBuilder.documentType = documentTypes[i]
+                    documentBuilder.checksum = checksums[i]
+                }.build()
+            }
+        }
+    val anyValidValidationRequest: Arb<ValidationRequest> = Arb.bind(
+        anyUuid,
+        anyPastNonEpochTimestamp,
+        anyUuid,
+        Arb.long(min = 0L),
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+    ) { requestId, effectiveTime, ruleSetId, blockHeight, description, validatorName, requesterName ->
+        ValidationRequest.newBuilder().also { requestBuilder ->
+            requestBuilder.requestId = requestId
+            requestBuilder.effectiveTime = effectiveTime
+            requestBuilder.ruleSetId = ruleSetId
+            requestBuilder.blockHeight = blockHeight
+            requestBuilder.description = description
+            requestBuilder.validatorName = validatorName
+            requestBuilder.requesterName = requesterName
+        }.build()
+    }
+    val anyValidValidationItem: Arb<ValidationItem> = Arb.bind(
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.of(ValidationOutcome.EXCEPTION, ValidationOutcome.WARNING, ValidationOutcome.VALID),
+    ) { code, label, description, expression, outcome ->
+        ValidationItem.newBuilder().also { validationItemBuilder ->
+            validationItemBuilder.code = code
+            validationItemBuilder.label = label
+            validationItemBuilder.description = description
+            validationItemBuilder.expression = expression
+            validationItemBuilder.validationOutcome = outcome
+        }.build()
+    }
+    val anyValidValidationResponse: Arb<ValidationResponse> = Arb.bind(
+        anyUuid,
+        anyUuid,
+        anyPastNonEpochTimestamp,
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.int(min = 0),
+        Arb.int(min = 0),
+        Arb.list(anyValidValidationItem, range = 1..(if (KotestConfig.runTestsExtended) 50 else 10)),
+        Arb.list(anyValidDocumentMetadata, range = 0..(if (KotestConfig.runTestsExtended) 50 else 10)),
+    ) { requestId, resultSetId, effectiveTime, providerName, exceptionCount, warningCount, validationItems, policyDocuments ->
+        ValidationResponse.newBuilder().also { responseBuilder ->
+            responseBuilder.requestId = requestId
+            responseBuilder.results = ValidationResults.newBuilder().also { resultsBuilder ->
+                resultsBuilder.resultSetUuid = resultSetId
+                resultsBuilder.resultSetEffectiveTime = effectiveTime
+                resultsBuilder.resultSetProvider = providerName
+                resultsBuilder.validationExceptionCount = exceptionCount
+                resultsBuilder.validationWarningCount = warningCount
+                resultsBuilder.clearValidationItems()
+                resultsBuilder.addAllValidationItems(validationItems)
+                resultsBuilder.clearPolicyDocuments()
+                resultsBuilder.addAllPolicyDocuments(policyDocuments)
+            }.build()
+        }.build()
+    }
+    fun anyValidValidationIteration(
+        itemCount: IntRange = 1..5,
+        policyDocumentCount: IntRange = 0..5,
+    ): Arb<ValidationIteration> = Arb.bind(
+        anyValidValidationRequest,
+        anyUuid,
+        anyPastNonEpochTimestamp,
+        Arb.int(min = 0),
+        Arb.int(min = 0),
+        Arb.list(anyValidValidationItem, itemCount),
+        Arb.list(anyValidDocumentMetadata, policyDocumentCount),
+    ) { request, resultSetId, effectiveTime, exceptionCount, warningCount, validationItems, policyDocuments ->
+        ValidationIteration.newBuilder().also { iterationBuilder ->
+            iterationBuilder.request = request
+            iterationBuilder.results = ValidationResults.newBuilder().also { resultsBuilder ->
+                resultsBuilder.resultSetUuid = resultSetId
+                resultsBuilder.resultSetEffectiveTime = effectiveTime
+                resultsBuilder.resultSetProvider = request.validatorName
+                resultsBuilder.validationExceptionCount = exceptionCount
+                resultsBuilder.validationWarningCount = warningCount
+                resultsBuilder.clearValidationItems()
+                resultsBuilder.addAllValidationItems(validationItems)
+                resultsBuilder.clearPolicyDocuments()
+                resultsBuilder.addAllPolicyDocuments(policyDocuments)
+            }.build()
+        }.build()
+    }
+    /* Loan scope records */
+    inline fun <reified T : Message> anyValidAsset(): Arb<Asset> =
+        when (T::class) {
+            FigureTechLoan::class -> LoanScopeProperties.assetLoanKey to anyValidFigureTechLoan
+            MISMOLoanMetadata::class -> LoanScopeProperties.assetMismoKey to anyValidMismoLoan
+            else -> throw IllegalArgumentException("Must supply an expected loan type for an asset")
+        }.let { (loanKey, anyLoan) ->
+            Arb.bind(
+                anyUuid,
+                PrimitiveArbs.anyNonEmptyString,
+                anyLoan,
+            ) { assetId, assetType, loan ->
+                Asset.newBuilder().also { assetBuilder ->
+                    assetBuilder.id = assetId
+                    assetBuilder.type = assetType
+                    assetBuilder.putKv(loanKey, loan.toProtoAny())
+                }.build()
+            }
+        }
+    fun anyValidENote(
+        minAssumptionCount: Int = 0,
+        maxAssumptionCount: Int = 10,
+        minModificationCount: Int = 0,
+        maxModificationCount: Int = 10,
+    ): Arb<ENote> = Arb.bind(
+        anyValidENoteController,
+        anyValidDocumentMetadata,
+        anyPastNonEpochDate,
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.list(anyValidDocumentMetadata, range = minModificationCount..maxModificationCount),
+        Arb.list(anyValidDocumentMetadata, range = minAssumptionCount..maxAssumptionCount),
+    ) { controller, document, signedDate, vaultName, modifications, assumptions ->
+        ENote.newBuilder().also { eNoteBuilder ->
+            eNoteBuilder.controller = controller
+            eNoteBuilder.eNote = document
+            eNoteBuilder.signedDate = signedDate
+            eNoteBuilder.vaultName = vaultName
+            eNoteBuilder.clearModification()
+            eNoteBuilder.addAllModification(modifications)
+            eNoteBuilder.clearAssumption()
+            eNoteBuilder.addAllAssumption(assumptions)
+        }.build()
+    }
+    val anyValidServicingRights: Arb<ServicingRights> = Arb.bind(
+        anyUuid,
+        PrimitiveArbs.anyNonEmptyString
+    ) { servicerId, servicerName ->
+        ServicingRights.newBuilder().also { servicingRightsBuilder ->
+            servicingRightsBuilder.servicerId = servicerId
+            servicingRightsBuilder.servicerName = servicerName
+        }.build()
+    }
+    fun anyValidLoanDocumentSet(size: Int, slippage: Int = 10): Arb<LoanDocuments> =
+        anyValidDocumentSet(size = size, slippage = slippage).map { documentList ->
+            LoanDocuments.newBuilder().also { documentsBuilder ->
+                documentsBuilder.clearDocument()
+                documentsBuilder.addAllDocument(documentList)
+            }.build()
+        }
+    fun anyValidServicingData(loanStateCount: Int, slippage: Int = 10): Arb<ServicingData> =
+        Arb.bind(
+            anyValidDocumentSet(size = loanStateCount, slippage = slippage),
+            loanStateSet(size = loanStateCount, slippage = slippage),
+        ) { documents, loanStates ->
+            ServicingData.newBuilder().also { servicingDataBuilder ->
+                servicingDataBuilder.clearDocMeta()
+                servicingDataBuilder.addAllDocMeta(documents)
+                servicingDataBuilder.clearLoanState()
+                servicingDataBuilder.addAllLoanState(loanStates)
+            }.build()
+        }
+    fun anyValidValidationRecord(
+        iterationCount: Int,
+        slippage: Int = 30,
+        itemCounts: IntRange = 1..5,
+        policyDocumentCounts: IntRange = 0..5,
+    ): Arb<LoanValidation> = Arb.bind(
+        Arb.list(
+            anyValidValidationIteration(itemCount = itemCounts, policyDocumentCount = policyDocumentCounts),
+            range = iterationCount..iterationCount
+        ),
+        anyUuidSet(size = iterationCount, slippage = slippage),
+    ) { randomIterations, requestIds ->
+        randomIterations.mapIndexed { index, iteration ->
+            iteration.toBuilder().also { iterationBuilder ->
+                iterationBuilder.request = iterationBuilder.request.toBuilder().also { requestBuilder ->
+                    requestBuilder.requestId = requestIds[index]
+                }.build()
+            }.build()
+        }.let { iterations ->
+            LoanValidation.newBuilder().also { recordBuilder ->
+                recordBuilder.clearIteration()
+                recordBuilder.addAllIteration(iterations)
+            }.build()
+        }
+    }
+    inline fun <reified T : Message> anyValidLoan(
+        maxAssumptionCount: Int = 0,
+        maxModificationCount: Int = 0,
+        loanStateCount: Int = 3,
+        iterationCount: Int = 3,
+        loanDocumentCount: Int = 3,
+    ): Arb<LoanPackage> = Arb.bind(
+        anyValidAsset<T>(),
+        anyValidENote(maxAssumptionCount = maxAssumptionCount, maxModificationCount = maxModificationCount),
+        anyValidServicingRights,
+        anyValidServicingData(loanStateCount = loanStateCount),
+        anyValidValidationRecord(iterationCount = iterationCount),
+        anyValidLoanDocumentSet(size = loanDocumentCount),
+    ) { randomAsset, randomENote, randomServicingRights, randomServicingData, randomValidationRecord, randomLoanDocuments ->
+        LoanPackage(
+            asset = randomAsset,
+            eNote = randomENote,
+            servicingRights = randomServicingRights,
+            servicingData = randomServicingData,
+            loanValidations = randomValidationRecord,
+            documents = randomLoanDocuments,
+        )
+    }
 }
 
 private val anyTimestampComponents: Arb<Pair<Long, Int>> = Arb.pair(
@@ -164,22 +459,34 @@ private val anyTimestampComponents: Arb<Pair<Long, Int>> = Arb.pair(
     Arb.int(min = Timestamps.MIN_VALUE.nanos, max = Timestamps.MAX_VALUE.nanos),
 )
 
+private val anyFutureTimestampComponents: Arb<Pair<Long, Int>> = Instant.now().let { now ->
+    Arb.pair(
+        Arb.long(min = now.epochSecond + 1800, max = Timestamps.MAX_VALUE.seconds), // 30 minute buffer
+        Arb.int(min = now.nano, max = Timestamps.MAX_VALUE.nanos),
+    )
+}
+
 private val anyPastNonEpochTimestampComponents: Arb<Pair<Long, Int>> = Instant.now().let { now ->
     if (KotestConfig.runTestsExtended) {
         Arb.pair(
             Arb.long(min = Timestamps.MIN_VALUE.seconds, max = now.epochSecond),
             Arb.int(min = Timestamps.MIN_VALUE.nanos, max = now.nano),
         ).filterNot { (seconds, nanoSeconds) ->
-            seconds == Timestamps.MIN_VALUE.seconds && nanoSeconds == Timestamps.MIN_VALUE.nanos
+            seconds == 0L && nanoSeconds == 0
         }
     } else {
         Arb.pair(
             Arb.long(min = Timestamps.MIN_VALUE.seconds, max = now.epochSecond),
             Arb.int(min = Timestamps.MIN_VALUE.nanos + 1, max = now.nano), // Minor sacrifice of case where nanos = 0, in exchange for faster runs
         )
-    }.filterNot { (seconds, nanoSeconds) ->
-        seconds == 0L && nanoSeconds == 0
     }
+}
+
+private fun Arb<Pair<Long, Int>>.toTimestamp(): Arb<Timestamp> = map { (seconds, nanoSeconds) ->
+    Timestamp.newBuilder().also { timestampBuilder ->
+        timestampBuilder.seconds = seconds
+        timestampBuilder.nanos = nanoSeconds
+    }.build()
 }
 
 /**
@@ -197,9 +504,9 @@ internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolati
             exception.overallViolationCount == violationCount,
             {
                 "Exception had ${violationPrinter(exception.overallViolationCount)} " +
-                    "but we expected ${violationPrinter(violationCount)}"
+                    "but we expected ${violationPrinter(violationCount)} - message was ${exception.message}"
             },
-            { "Exception should not have ${violationPrinter(violationCount)}" },
+            { "Exception should not have ${violationPrinter(violationCount)} - message was ${exception.message}" },
         )
     }
 }
@@ -207,12 +514,33 @@ internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolati
 /**
  * Wraps the custom matcher [throwViolationCount] following the style outlined in the
  * [Kotest documentation](https://kotest.io/docs/assertions/custom-matchers.html#extension-variants).
+ * This should be called by the result of any [`shouldThrow<ContractViolationException>`][io.kotest.assertions.throwables.shouldThrow].
  */
 internal infix fun ContractViolationException.shouldHaveViolationCount(violationCount: UInt) = apply {
     this should throwViolationCount(violationCount)
 }
 
-internal infix fun UnexpectedContractStateException.shouldBeParseFailureFor(classifier: String) = apply {
-    this.cause should beInstanceOf<InvalidProtocolBufferException>()
-    this.message shouldBe "Could not unpack as class $classifier"
+internal fun IllegalContractStateException.shouldBeParseFailureFor(classifier: String, inputDescription: String = "input") = apply {
+    message shouldContain "Could not unpack the $inputDescription as class $classifier"
 }
+
+internal infix fun UnexpectedContractStateException.shouldBeParseFailureFor(classifier: String) = apply {
+    cause should beInstanceOf<InvalidProtocolBufferException>()
+    message shouldBe "Could not unpack as class $classifier"
+}
+
+internal fun Iterable<DocumentMetadata>.toRecord(): LoanDocuments = LoanDocuments.newBuilder().also { recordBuilder ->
+    recordBuilder.clearDocument()
+    recordBuilder.addAllDocument(this)
+}.build()
+
+internal fun <T> List<T>.breakOffLast(): Pair<List<T>, T> {
+    require(isNotEmpty()) {
+        "Must supply a list with at least one element"
+    }
+    return dropLast(1) to takeLast(1)[0]
+}
+
+internal fun <T> Arb<List<T>>.toPair(): Arb<Pair<T, T>> = map { list -> list[0] to list[1] }
+
+internal fun <S, T> Arb<S>.toPair(fn: (S) -> List<T>): Arb<Pair<T, T>> = map(fn).toPair()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -13,7 +13,7 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.list
 import io.kotest.property.checkAll
-import io.provenance.scope.loan.test.LoanPackageArbs
+import io.provenance.scope.loan.test.PrimitiveArbs
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 
 class ContractRequirementsUnitTest : WordSpec({
@@ -44,7 +44,7 @@ class ContractRequirementsUnitTest : WordSpec({
                 }
             }
             "return state violations only for failed conditions" {
-                checkAll(Arb.list(LoanPackageArbs.anyContractEnforcement)) { enforcementList ->
+                checkAll(Arb.list(PrimitiveArbs.anyContractEnforcement)) { enforcementList ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<IllegalContractStateException> {
@@ -60,7 +60,7 @@ class ContractRequirementsUnitTest : WordSpec({
                 }
             }
             "return input violations only for failed conditions" {
-                checkAll(Arb.list(LoanPackageArbs.anyContractEnforcement)) { enforcementList ->
+                checkAll(Arb.list(PrimitiveArbs.anyContractEnforcement)) { enforcementList ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementList)
                     if (expectedOverallViolationCount > 0U) {
                         shouldThrow<ContractViolationException> {
@@ -84,8 +84,8 @@ class ContractRequirementsUnitTest : WordSpec({
             }
             "return state violations only for failed conditions" {
                 checkAll(
-                    Arb.list(LoanPackageArbs.anyContractEnforcement),
-                    Arb.list(LoanPackageArbs.anyContractEnforcement),
+                    Arb.list(PrimitiveArbs.anyContractEnforcement),
+                    Arb.list(PrimitiveArbs.anyContractEnforcement),
                 ) { enforcementListA, enforcementListB ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
                     if (expectedOverallViolationCount > 0U) {
@@ -115,8 +115,8 @@ class ContractRequirementsUnitTest : WordSpec({
             }
             "return input violations only for failed conditions" {
                 checkAll(
-                    Arb.list(LoanPackageArbs.anyContractEnforcement),
-                    Arb.list(LoanPackageArbs.anyContractEnforcement),
+                    Arb.list(PrimitiveArbs.anyContractEnforcement),
+                    Arb.list(PrimitiveArbs.anyContractEnforcement),
                 ) { enforcementListA, enforcementListB ->
                     val expectedOverallViolationCount = getExpectedViolationCount(enforcementListA + enforcementListB)
                     if (expectedOverallViolationCount > 0U) {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
@@ -1,16 +1,19 @@
 package io.provenance.scope.loan.utility
 
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.shouldBe
-import io.kotest.property.Arb
-import io.kotest.property.arbitrary.string
+import io.kotest.matchers.string.shouldContain
 import io.kotest.property.checkAll
-import io.provenance.scope.loan.test.LoanPackageArbs
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidChecksum
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidFigureTechLoan
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidMismoLoan
 import io.provenance.scope.loan.test.shouldBeParseFailureFor
+import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.proto.util.toProtoAny
+import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
@@ -18,16 +21,14 @@ class DataConversionExtensionsUnitTest : WordSpec({
     "unpackAs" When {
         "given a packed protobuf to unpack as the same type it was packed as" should {
             "not throw an exception" {
-                checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
-                    shouldNotThrow<UnexpectedContractStateException> {
-                        randomChecksum.toProtoAny().unpackAs<FigureTechChecksum>() shouldBe randomChecksum
-                    }
+                checkAll(anyValidChecksum) { randomChecksum ->
+                    randomChecksum.toProtoAny().unpackAs<FigureTechChecksum>() shouldBe randomChecksum
                 }
             }
         }
         "given a packed protobuf to unpack as a type with inherently different fields than the type it was packed as" should {
             "throw an appropriate exception" {
-                checkAll(LoanPackageArbs.anyValidChecksum) { randomChecksum ->
+                checkAll(anyValidChecksum) { randomChecksum ->
                     shouldThrow<UnexpectedContractStateException> {
                         randomChecksum.toProtoAny().unpackAs<FigureTechUUID>()
                     }.let { exception ->
@@ -38,68 +39,114 @@ class DataConversionExtensionsUnitTest : WordSpec({
         }
     }
     "tryUnpackingAs" When {
-        "given a packed protobuf to unpack as the same type it was packed as" xshould {
+        "given a packed protobuf to unpack as the same type it was packed as" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(anyUuid) { randomId ->
+                    validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                        randomId.toProtoAny().tryUnpackingAs<FigureTechUUID> { unpacked ->
+                            unpacked shouldBe randomId
+                        }
+                    }
+                }
             }
         }
-        "given a packed protobuf to unpack as a type with inherently different fields than the type it was packed as" xshould {
+        "given a packed protobuf to unpack as a type with inherently different fields than the type it was packed as" should {
             "throw an appropriate exception" {
-                // TODO: Implement
+                checkAll(anyValidChecksum) { randomChecksum ->
+                    shouldThrow<IllegalContractStateException> {
+                        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                            randomChecksum.toProtoAny().tryUnpackingAs<FigureTechUUID> {}
+                        }
+                    }.let { exception ->
+                        exception.shouldBeParseFailureFor(classifier = "tech.figure.util.v1beta1.UUID")
+                    }
+                }
             }
         }
-        "given a packed Figure Tech loan to unpack as a MISMO loan with inherently different fields" xshould {
+        "given a packed Figure Tech loan to unpack as a MISMO loan with inherently different fields" should {
             "throw an appropriate informative exception" {
-                // TODO: Implement
+                checkAll(anyValidFigureTechLoan) { randomLoan ->
+                    shouldThrow<IllegalContractStateException> {
+                        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                            randomLoan.toProtoAny().tryUnpackingAs<MISMOLoanMetadata> {}
+                        }
+                    }.let { exception ->
+                        exception.message shouldContain
+                            "Expected input to be a ${MISMOLoanMetadata::class.java} but was actually a ${FigureTechLoan::class.java}"
+                    }
+                }
             }
         }
-        "given a packed MISMO loan to unpack as a Figure Tech loan with inherently different fields" xshould {
+        "given a packed MISMO loan to unpack as a Figure Tech loan with inherently different fields" should {
             "throw an appropriate informative exception" {
-                // TODO: Implement
+                checkAll(anyValidMismoLoan) { randomLoan ->
+                    shouldThrow<IllegalContractStateException> {
+                        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                            randomLoan.toProtoAny().tryUnpackingAs<FigureTechLoan> {}
+                        }
+                    }.let { exception ->
+                        exception.message shouldContain
+                            "Expected input to be a ${FigureTechLoan::class.java} but was actually a ${MISMOLoanMetadata::class.java}"
+                    }
+                }
             }
         }
     }
     "toFigureTechLoan" When {
         "called on a non-null inapplicable protobuf" should {
             "throw an appropriate exception for unpacking" {
-                checkAll(Arb.string(), Arb.string()) { randomChecksumString, randomAlgorithmString ->
-                    FigureTechChecksum.newBuilder().apply {
-                        checksum = randomChecksumString
-                        algorithm = randomAlgorithmString
-                    }.build().let { randomChecksum ->
-                        shouldThrow<UnexpectedContractStateException> {
-                            randomChecksum?.toProtoAny()?.toFigureTechLoan()
-                        }.let { exception ->
-                            exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
-                        }
-                        // Sanity check that parsing is only attempted when intended by code
-                        IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
-                            shouldThrow<IllegalArgumentException> {
-                                randomChecksum.takeIf { false }?.toProtoAny()?.toFigureTechLoan()
-                                    ?: throw callerException
-                            }.let { thrownException ->
-                                thrownException shouldBe callerException
-                            }
+                checkAll(anyValidChecksum) { randomChecksum ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        randomChecksum.toProtoAny().toFigureTechLoan()
+                    }.let { exception ->
+                        exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.Loan"
+                    }
+                    // Sanity check that parsing is only attempted when intended by code
+                    IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
+                        shouldThrow<IllegalArgumentException> {
+                            randomChecksum.takeIf { false }?.toProtoAny()?.toFigureTechLoan()
+                                ?: throw callerException
+                        }.let { thrownException ->
+                            thrownException shouldBe callerException
                         }
                     }
                 }
             }
         }
-        "called on a packed Figure Tech loan" xshould {
+        "called on a packed Figure Tech loan" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(anyValidFigureTechLoan) { randomLoan ->
+                    randomLoan.toProtoAny().toFigureTechLoan() shouldBe randomLoan
+                }
             }
         }
     }
-    "toMISMOLoan" xshould {
-        "called on a non-null inapplicable protobuf" xshould {
+    "toMISMOLoan" When {
+        "called on a non-null inapplicable protobuf" should {
             "throw an appropriate exception for unpacking" {
-                // TODO: Implement
+                checkAll(anyValidChecksum) { randomChecksum ->
+                    shouldThrow<UnexpectedContractStateException> {
+                        randomChecksum.toProtoAny().toMISMOLoan()
+                    }.let { exception ->
+                        exception shouldBeParseFailureFor "tech.figure.loan.v1beta1.MISMOLoanMetadata"
+                    }
+                    // Sanity check that parsing is only attempted when intended by code
+                    IllegalArgumentException("Expected the receiver's algorithm to not be set").let { callerException ->
+                        shouldThrow<IllegalArgumentException> {
+                            randomChecksum.takeIf { false }?.toProtoAny()?.toMISMOLoan()
+                                ?: throw callerException
+                        }.let { thrownException ->
+                            thrownException shouldBe callerException
+                        }
+                    }
+                }
             }
         }
-        "called on a packed MISMO loan" xshould {
+        "called on a packed MISMO loan" should {
             "not throw an exception" {
-                // TODO: Implement
+                checkAll(anyValidMismoLoan) { randomLoan ->
+                    randomLoan.toProtoAny().toMISMOLoan() shouldBe randomLoan
+                }
             }
         }
     }


### PR DESCRIPTION
## Changes
### Patch
- Add a bunch more unit tests (see code coverage diff in bot comment below)
- Fix some wording, copy-paste, and other minor issues in some contracts
- Add a test class for printing out JSON of random loan scope records
- Slightly refactor date/time-related validation extensions & Kotest helpers to have more specific names
- Use `isSet()` more often in input validation to condense errors for individual fields when the protobuf is simply not defined
- Adjust structure and logic of many Kotest helpers
- Refactor older unit tests (like ones for validation contracts) to use `checkAll` style and new composite `Arb`s
- Fix issues with build workflow syntax
- Update TODOs
## Notes
- I added some test classes not tied to a specific contract class (like `OverwriteServicingRights`) to group tests that use the same DRYed logic together, regardless of which contract is the caller