### PR TITLE
Require checksum algorithms, fix loan key usage, add tests for wrong loan type

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -62,7 +62,7 @@ open class RecordLoanContract(
                 )
             }
             if (newAsset.containsKv(assetLoanKey) xor newAsset.containsKv(assetMismoKey)) {
-                newAsset.kvMap["loan"]?.let { newLoanValue ->
+                newAsset.kvMap[assetLoanKey]?.let { newLoanValue ->
                     newLoanValue.tryUnpackingAs<FigureTechLoan>("input asset's \"${assetLoanKey}\"") { newLoan ->
                         if (existingAsset.isSet()) {
                             existingAsset!!.kvMap[assetLoanKey]?.toFigureTechLoan()?.let { existingLoan ->

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -47,7 +47,7 @@ internal fun FigureTechDate?.isValidForSignedDate() = isSet() && this!!.value.is
     JavaLocalDate.parse(value) <= JavaLocalDate.now()
 }
 
-internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank() // Check for algorithm is omitted
+internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank() && algorithm.isNotBlank()
 
 internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse { JavaUUID.fromString(value) }
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
@@ -15,7 +15,6 @@ internal fun ContractEnforcementContext.documentModificationValidation(
     newDocument: DocumentMetadata,
 ) {
     existingDocument.checksum.checksum.let { existingChecksum ->
-        // TODO: Should we raise a violation if the checksum's algorithm is changed?
         if (existingChecksum == newDocument.checksum.checksum) {
             val checksumSnippet = if (existingChecksum.isNotBlank()) {
                 " with checksum $existingChecksum"
@@ -23,6 +22,8 @@ internal fun ContractEnforcementContext.documentModificationValidation(
                 ""
             }
             requireThat(
+                (existingDocument.checksum.algorithm == newDocument.checksum.algorithm)
+                    orError "Cannot change checksum algorithm of existing document$checksumSnippet",
                 (existingDocument.id == newDocument.id)
                     orError "Cannot change ID of existing document$checksumSnippet",
                 (existingDocument.uri == newDocument.uri)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationExtensionsUnitTest.kt
@@ -109,10 +109,11 @@ class DataValidationExtensionsUnitTest : WordSpec({
                 }.build().isValid()
             }
         }
-        "return true for any non-empty checksum string" {
-            forAll(anyNonEmptyString) { randomString ->
+        "return true for any pair of non-empty strings" {
+            forAll(anyNonEmptyString, anyNonEmptyString) { randomChecksum, randomAlgorithm ->
                 FigureTechChecksum.newBuilder().apply {
-                    checksum = randomString
+                    checksum = randomChecksum
+                    algorithm = randomAlgorithm
                 }.build().isValid()
             }
         }


### PR DESCRIPTION
## Changes
- Require checksums to define a non-blank algorithm string
- Fix loan key references not using the string constants
- Implement test cases for supplying the wrong type of loan to update an existing loan
- Clean up some code in `RecordLoanContractUnitTest`