### PR TITLE
Convert to using release drafter to better control semantic versioning

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,51 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features & Enhancements'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+  - title: '📖 Documentation'
+    label: 'docs'
+  - title: '📦 Dependency Updates'
+    label: 'dependencies'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+autolabeler:
+  - label: 'enhancement'
+    title:
+      - '/(feat)|(refactor)/i'
+  - label: 'bug'
+    branch:
+      - '/fix\/.+/'
+    title:
+      - '/fix/i'
+  - label: 'docs'
+    title:
+      - '/docs/i'
+template: |
+  # Changelog
+  $CHANGES
+  # Notes
+  ## Contributors
+  $CONTRIBUTORS
+  ## Deployment Dependencies
+  List the relevant PRs and work that needs to be done for this release's publications to be used successfully here
+  ## Other
+  Other notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,12 @@ name: Build and Publish
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: 'The version to publish'
+        required: true
+        type: string
       publishing_environment:
-        description: 'Environment the contracts should be bootstrapped to'
+        description: 'Environment to bootstrap the contracts to'
         required: true
         default: 'testnet'
         type: choice
@@ -12,41 +16,22 @@ on:
           - 'testnet'
           - 'mainnet'
       os_url:
-        description: Object Store URL
+        description: 'Object Store URL'
         default: 'grpcs://test.figure.com/objectstore.'
         required: true
         type: string
       prov_url:
-        description: Provenance URL
+        description: 'Provenance URL'
         default: 'grpcs://34.148.39.82:9090'
         required: true
         type: string
       chain_id:
-        description: Chain Id
+        description: 'Chain ID'
         default: 'pio-testnet-1'
         required: true
         type: string
 
 jobs:
-  linting:
-    name: Linting
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '11'
-
-      - name: Linting
-        run: ./gradlew clean ktlintCheck --parallel
-
   build-and-publish:
     name: Build and Publish Jar
     runs-on: ubuntu-latest
@@ -65,6 +50,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.version }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -73,7 +59,7 @@ jobs:
           java-version: '11'
 
       - name: Build with Gradle
-        run: ./gradlew -i clean build --refresh-dependencies :generateVersionFile githubRelease --stacktrace
+        run: ./gradlew -i clean build --refresh-dependencies -x koverVerify -x koverReport --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -83,26 +69,24 @@ jobs:
       - name: Bootstrap Test
         run: ./gradlew p8eBootstrap --info
 
-      - name: Create Outputs
-        run: |-
-          echo "::set-output name=semVersion::$(cat build/semver/version.txt | head -1)"
-          echo "::set-output name=semVersionTag::$(cat build/semver/version.txt | tail -1)"
-        id: ci-release-create-outputs
-        shell: bash
-
       - name: Install gpg secret key
         run: |
           export GPG_TTY=$(tty)
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode | gpg --batch --import
           gpg --list-secret-keys --keyid-format LONG
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
-          
+
       - name: Publish to Maven Central
         run: |
-          ./gradlew publishToSonatype -Psemver.overrideVersion=${{ steps.ci-release-create-outputs.outputs.semVersion }} $(if [ "${{github.event.release.prerelease}}" = "true" ]; then echo 'closeSonatypeStagingRepository'; else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
-            -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
+          ./gradlew publishToSonatype -Pversion="$VERSION" \
+            $(if [ "${{github.event.release.prerelease}}" = "true" ]; \
+              then echo 'closeSonatypeStagingRepository'; \
+              else echo 'closeAndReleaseSonatypeStagingRepository'; fi) \
+            -Psigning.keyId=B7D30ABE -Psigning.password="${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}" \
+            -Psigning.secretKeyRingFile=$GITHUB_WORKSPACE/release.gpg \
             --info
         env:
+          VERSION: $( echo ${{ github.event.inputs.version }} | sed -e 's/^v//' )
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+# Runs autolabeler on every PR
+# Creates/updates draft release on every push to master
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  update-release-draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v5.20.0
+        with:
+          # allows autolabeler to run without unmerged PRs from being added to draft
+          disable-releaser: ${{ github.ref_name != github.event.repository.default_branch }} # Should be the branch that gets releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,6 @@ import io.provenance.p8e.plugin.P8ePartyExtension
 /** Build setup */
 
 buildscript {
-    classpathSpecs(
-        Dependencies.SemVer,
-        Dependencies.GitHubRelease,
-    )
     repositories {
         mavenCentral()
         maven { url = uri(RepositoryLocations.JitPack) }
@@ -22,7 +18,6 @@ plugins {
         Plugins.GitHubRelease,
         Plugins.NexusPublishing,
         Plugins.P8ePublishing,
-        Plugins.SemVer,
     )
     signing
 }
@@ -75,21 +70,8 @@ val ktlintFormat by tasks.creating(JavaExec::class) {
     args = listOf("-F", "*/src/**/*.kt") + ktlintExcludeSyntax(lintingExclusions)
 }
 
-/** Project Setup & Releasing */
-
-semver {
-    tagPrefix("v")
-    initialVersion("0.1.0")
-    overrideVersion("0.2.0") // TODO: Remove immediately after merges to main
-    findProperty("semver.overrideVersion")?.toString()?.let { overrideVersion(it) }
-    val semVerModifier = findProperty("semver.modifier")?.toString()?.let { buildVersionModifier(it) } ?: { nextPatch() }
-    versionModifier(semVerModifier)
-}
-
-val semVersion = semver.version
 allprojects {
     group = "io.provenance.loan-package"
-    version = semVersion
 
     repositories {
         mavenCentral()
@@ -185,24 +167,6 @@ nexusPublishing {
             stagingProfileId.set("3180ca260b82a7") // prevents querying for the staging profile id, performance optimization
         }
     }
-}
-
-val githubTokenValue = findProperty("githubToken")?.toString() ?: System.getenv("GITHUB_TOKEN")
-
-githubRelease {
-    token(githubTokenValue)
-    owner("provenance-io")
-    targetCommitish("main")
-    draft(false)
-    prerelease(false)
-    repo("loan-package-contracts")
-    tagName(semver.versionTagName)
-    body(changelog())
-
-    overwrite(false)
-    dryRun(false)
-    apiEndpoint("https://api.github.com")
-    client
 }
 
 fun p8eParty(publicKey: String): P8ePartyExtension = P8ePartyExtension().also { it.publicKey = publicKey }


### PR DESCRIPTION
## Context
The GitHub release plugin is just terrible IMO - it provides a small convenience by sacrificing the abilities to
- control the type of semantic versioning change a PR introduces
- separate GitHub release creation from publishing so that publishing failures do not require empty re-releases

Using [Release Drafter](https://github.com/release-drafter/release-drafter) will address those issues and give everyone better clarity on changes.
## Changes
### Patch
- Add release drafter configuration files
- Adjust publishing workflow to use inputted version of code
- Remove GitHub release and semver plugins from root build
- Remove linting job from publishing workflow
- Remove code coverage jobs from publish workflow's build step