### PR TITLE
Introduce more precise violation errors for checksums

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
@@ -11,7 +11,6 @@ import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.documentModificationValidation
 import io.provenance.scope.loan.utility.documentValidation
-import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.raiseError
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.loan.v1beta1.LoanDocuments
@@ -32,7 +31,7 @@ open class AppendLoanDocumentsContract(
             val existingDocumentMetadata = mutableMapOf<String, DocumentMetadata>()
             if (newDocs.documentList.isNotEmpty()) {
                 existingDocs?.documentList?.forEach { documentMetadata ->
-                    documentMetadata.checksum.takeIf { it.isValid() }?.checksum?.let { checksum ->
+                    documentMetadata.checksum.checksum.takeIf { it.isNotBlank() }?.let { checksum ->
                         existingDocumentMetadata[checksum] = documentMetadata
                     }
                 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -6,7 +6,6 @@ import com.google.protobuf.Message as ProtobufMessage
 import com.google.protobuf.Timestamp as ProtobufTimestamp
 import java.time.LocalDate as JavaLocalDate
 import java.util.UUID as JavaUUID
-import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.Money as FigureTechMoney
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
@@ -46,8 +45,6 @@ internal fun FigureTechDate?.isValid() = isSet() && this!!.value.isNotBlank() &&
 internal fun FigureTechDate?.isValidForSignedDate() = isSet() && this!!.value.isNotBlank() && falseIfError {
     JavaLocalDate.parse(value) <= JavaLocalDate.now()
 }
-
-internal fun FigureTechChecksum?.isValid() = isSet() && this!!.checksum.isNotBlank() && algorithm.isNotBlank()
 
 internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse { JavaUUID.fromString(value) }
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
@@ -44,7 +44,7 @@ internal fun ContractEnforcementContext.appendLoanStates(
     val existingStateTimes = mutableMapOf<Pair<Long, Int>, Boolean>()
     if (newLoanStates.isNotEmpty()) {
         servicingDataBuilder.loanStateList.forEach { loanState ->
-            loanState?.checksum.takeIf { it.isValid() }?.checksum?.let { checksum ->
+            loanState?.checksum?.checksum?.takeIf { it.isNotBlank() }?.let { checksum ->
                 existingStateChecksums[checksum] = true
             }
             loanState?.id.takeIf { it.isValid() }?.value?.let { id ->

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContractUnitTest.kt
@@ -56,7 +56,7 @@ class AppendLoanStatesContractUnitTest : WordSpec({
                         exception shouldHaveViolationCount 4U
                         exception.message shouldContainIgnoringCase "Loan state must have valid ID"
                         exception.message shouldContainIgnoringCase "Loan state is missing URI"
-                        exception.message shouldContainIgnoringCase "Loan state is missing checksum"
+                        exception.message shouldContainIgnoringCase "Loan state's checksum is not set"
                         exception.message shouldContainIgnoringCase "Loan state must have valid effective time"
                     }
                 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
@@ -176,7 +176,7 @@ class UpdateENoteContractUnitTest : WordSpec({
                         )
                     }.let { exception ->
                         exception shouldHaveViolationCount 1U
-                        exception.message shouldContain "eNote is missing checksum"
+                        exception.message shouldContain "eNote must have a valid checksum string"
                     }
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
@@ -1,9 +1,11 @@
 package io.provenance.scope.loan.utility
 
 import com.google.protobuf.Any
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.UUIDVersion
 import io.kotest.property.arbitrary.double
@@ -27,7 +29,8 @@ import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.Money as FigureTechMoney
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 
-class DataValidationExtensionsUnitTest : WordSpec({
+class DataValidationUnitTest : WordSpec({
+    /* DataValidationExtensions */
     "Message.isSet" should {
         "return false for any default instance" {
             ValidationIteration.getDefaultInstance().isSet() shouldBe false
@@ -92,32 +95,6 @@ class DataValidationExtensionsUnitTest : WordSpec({
             }
         }
     }
-    "Checksum.isValid" should {
-        "return false for a default instance" {
-            FigureTechChecksum.getDefaultInstance().isValid() shouldBe false
-        }
-        "return false for an invalid instance" {
-            FigureTechChecksum.newBuilder().apply {
-                checksum = ""
-            }.build().isValid() shouldBe false
-        }
-        "return false if the algorithm is set but not the checksum" {
-            forNone(anyNonEmptyString) { randomAlgorithm ->
-                FigureTechChecksum.newBuilder().apply {
-                    clearChecksum()
-                    algorithm = randomAlgorithm
-                }.build().isValid()
-            }
-        }
-        "return true for any pair of non-empty strings" {
-            forAll(anyNonEmptyString, anyNonEmptyString) { randomChecksum, randomAlgorithm ->
-                FigureTechChecksum.newBuilder().apply {
-                    checksum = randomChecksum
-                    algorithm = randomAlgorithm
-                }.build().isValid()
-            }
-        }
-    }
     "FigureTechUUID.isValid" should {
         "return false for a default instance" {
             FigureTechUUID.getDefaultInstance().isValid() shouldBe false
@@ -143,6 +120,62 @@ class DataValidationExtensionsUnitTest : WordSpec({
                 FigureTechMoney.newBuilder().apply {
                     amount = randomDouble
                 }.build().isValid()
+            }
+        }
+    }
+    /* LoanContractValidations */
+    "checksumValidation" should {
+        "throw an appropriate exception for a default instance" {
+            shouldThrow<ContractViolationException> {
+                validateRequirements(ContractRequirementType.VALID_INPUT) {
+                    checksumValidation(checksum = FigureTechChecksum.getDefaultInstance())
+                }
+            }.let { exception ->
+                exception.message shouldContain "Input's checksum is not set"
+            }
+        }
+        "throw an appropriate exception if the checksum is set but not the algorithm" {
+            checkAll(anyNonEmptyString) { randomChecksum ->
+                shouldThrow<ContractViolationException> {
+                    validateRequirements(ContractRequirementType.VALID_INPUT) {
+                        checksumValidation(
+                            checksum = FigureTechChecksum.newBuilder().apply {
+                                clearAlgorithm()
+                                checksum = randomChecksum
+                            }.build()
+                        )
+                    }
+                }.let { exception ->
+                    exception.message shouldContain "Input must specify a checksum algorithm"
+                }
+            }
+        }
+        "throw an appropriate exception if the algorithm is set but not the checksum" {
+            checkAll(anyNonEmptyString) { randomAlgorithm ->
+                shouldThrow<ContractViolationException> {
+                    validateRequirements(ContractRequirementType.VALID_INPUT) {
+                        checksumValidation(
+                            checksum = FigureTechChecksum.newBuilder().apply {
+                                clearChecksum()
+                                algorithm = randomAlgorithm
+                            }.build()
+                        )
+                    }
+                }.let { exception ->
+                    exception.message shouldContain "Input must have a valid checksum string"
+                }
+            }
+        }
+        "not throw an exception for any non-empty checksum and algorithm strings" {
+            checkAll(anyNonEmptyString, anyNonEmptyString) { randomChecksum, randomAlgorithm ->
+                validateRequirements(ContractRequirementType.VALID_INPUT) {
+                    checksumValidation(
+                        checksum = FigureTechChecksum.newBuilder().apply {
+                            checksum = randomChecksum
+                            algorithm = randomAlgorithm
+                        }.build()
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Context
In #30, we started requiring all checksums to provide an algorithm as well. The current error is thus a bit confusing as to what the problem may be with an input checksum, and checksums are fairly common across our contracts' inputs, so let's improve the messaging.
## Changes
### Patch
- Refactor checksum validation extension function into a contract requirement validation function, with different messaging for each case of
  - a checksum not being provided or having no fields set
  - a checksum with a checksum string but no algorithm string
  - a checksum with an algorithm string but no checksum string
- Start including tests for `LoanContractValidations` code in formerly named `DataValidationExtensions` file