### PR TITLE
Validate new originator ID & ULI fields during Loan recording

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -28,7 +28,7 @@ object Versions {
         const val JacksonProtobuf = "0.9.12"
         object Provenance {
             const val Scope = "0.6.1"
-            const val MetadataAssetModel = "0.1.10"
+            const val MetadataAssetModel = "0.1.11"
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -74,8 +74,10 @@ open class RecordLoanContract(
                         } else {
                             requireThat(
                                 newLoan.id.isValid()                orError "Loan must have valid ID",
+                                newLoan.originatorUuid.isValid()    orError "Loan must have valid originator ID",
                                 newLoan.originatorName.isNotBlank() orError "Loan is missing originator name",
                             )
+                            uliValidation(newLoan.uli)
                         }
                     }
                 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -222,11 +222,15 @@ internal object MetadataAssetModelArbs {
     }
     val anyValidFigureTechLoan: Arb<FigureTechLoan> = Arb.bind(
         anyUuid,
+        anyUuid,
         PrimitiveArbs.anyNonEmptyString,
-    ) { loanId, originatorName ->
+        PrimitiveArbs.anyValidUli,
+    ) { loanId, originatorUuid, originatorName, uli ->
         FigureTechLoan.newBuilder().also { loanBuilder ->
             loanBuilder.id = loanId
+            loanBuilder.originatorUuid = originatorUuid
             loanBuilder.originatorName = originatorName
+            loanBuilder.uli = uli
         }.build()
     }
     val anyValidMismoLoan: Arb<MISMOLoanMetadata> = Arb.bind(


### PR DESCRIPTION
## Context
Adds validation of the new `Loan` fields from [the latest metadata model update](https://github.com/provenance-io/metadata-asset-model/compare/v0.1.10...v0.1.11)