### PR TITLE
Add modification and assumption contracts

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -49,6 +49,8 @@ object LoanScopeInputs {
     const val eNoteUpdate = "newENote"
     const val eNoteControllerUpdate = "newController"
     const val newLoanStates = "newLoanStates"
+    const val newAssumption = "newAssumption"
+    const val newModification = "newModification"
 }
 
 /**

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AddENoteAssumptionContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AddENoteAssumptionContract.kt
@@ -1,0 +1,45 @@
+package io.provenance.scope.loan.contracts
+
+import io.dartinc.registry.v1beta1.ENote
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications.PartyType
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.documentModificationValidation
+import io.provenance.scope.loan.utility.documentValidation
+import io.provenance.scope.loan.utility.toChecksumMap
+import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.util.v1beta1.DocumentMetadata
+
+@Participants(roles = [PartyType.OWNER]) // To be invoked by either the servicer or sub-servicer
+@ScopeSpecification(["tech.figure.loan"])
+open class AddENoteAssumptionContract(
+    @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
+) : P8eContract() {
+
+    @Suppress("Duplicates") /** Identical to [AddENoteModificationContract.addModification]. */
+    @Function(invokedBy = PartyType.OWNER)
+    @Record(LoanScopeFacts.eNote)
+    open fun addAssumption(@Input(LoanScopeInputs.newAssumption) newAssumption: DocumentMetadata): ENote {
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            documentValidation(newAssumption)
+            /* Primitive type used for protobuf keys to avoid comparison interference from unknown fields */
+            val existingAssumptionDocumentMetadata = existingENote.assumptionList.toChecksumMap()
+            newAssumption.checksum.checksum.takeIf { it.isNotBlank() }?.let { newAssumptionChecksum ->
+                existingAssumptionDocumentMetadata[newAssumptionChecksum]?.let { existingAssumption ->
+                    documentModificationValidation(
+                        existingAssumption,
+                        newAssumption,
+                    )
+                }
+            }
+        }
+        return existingENote.toBuilder().addAssumption(newAssumption).build()
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AddENoteModificationContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AddENoteModificationContract.kt
@@ -1,0 +1,45 @@
+package io.provenance.scope.loan.contracts
+
+import io.dartinc.registry.v1beta1.ENote
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications.PartyType
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.documentModificationValidation
+import io.provenance.scope.loan.utility.documentValidation
+import io.provenance.scope.loan.utility.toChecksumMap
+import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.util.v1beta1.DocumentMetadata
+
+@Participants(roles = [PartyType.OWNER]) // To be invoked by either the servicer or sub-servicer
+@ScopeSpecification(["tech.figure.loan"])
+open class AddENoteModificationContract(
+    @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
+) : P8eContract() {
+
+    @Suppress("Duplicates") /** Identical to [AddENoteAssumptionContract.addAssumption]. */
+    @Function(invokedBy = PartyType.OWNER)
+    @Record(LoanScopeFacts.eNote)
+    open fun addModification(@Input(LoanScopeInputs.newModification) newModification: DocumentMetadata): ENote {
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            documentValidation(newModification)
+            /* Primitive type used for protobuf keys to avoid comparison interference from unknown fields */
+            val existingModificationDocumentMetadata = existingENote.modificationList.toChecksumMap()
+            newModification.checksum.checksum.takeIf { it.isNotBlank() }?.let { newModificationChecksum ->
+                existingModificationDocumentMetadata[newModificationChecksum]?.let { existingModification ->
+                    documentModificationValidation(
+                        existingModification,
+                        newModification,
+                    )
+                }
+            }
+        }
+        return existingENote.toBuilder().addModification(newModification).build()
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContract.kt
@@ -22,9 +22,6 @@ open class UpdateENoteContract(
     @Record(name = LoanScopeFacts.eNote, optional = false) val existingENote: ENote,
 ) : P8eContract() {
 
-    /**
-     * TODO: We may need to replace/augment this with new AddENoteModification and AddENoteAssumption contracts, pending more insight on that process
-     */
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.eNote)
     open fun updateENote(@Input(LoanScopeInputs.eNoteUpdate) newENote: DocumentMetadata): ENote {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
@@ -3,8 +3,17 @@ package io.provenance.scope.loan.utility
 import com.google.protobuf.InvalidProtocolBufferException
 import com.google.protobuf.Message
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
+import tech.figure.util.v1beta1.DocumentMetadata
 import com.google.protobuf.Any as ProtobufAny
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
+
+internal fun Iterable<DocumentMetadata>.toChecksumMap(): Map<String, DocumentMetadata> = mutableMapOf<String, DocumentMetadata>().also { map ->
+    forEach { document ->
+        document.checksum.checksum.takeIf { it.isNotBlank() }?.let { checksum ->
+            map[checksum] = document
+        }
+    }
+}
 
 context(ContractEnforcementContext)
 internal inline fun <reified T : Message> ProtobufAny.tryUnpackingAs(inputDescription: String = "input", body: (T) -> Any) {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ServicingDataFunctions.kt
@@ -104,12 +104,7 @@ internal fun ContractEnforcementContext.appendServicingDocuments(
     servicingDataBuilder: ServicingData.Builder,
     newDocuments: Collection<DocumentMetadata>,
 ) {
-    val existingDocumentMetadata = mutableMapOf<String, DocumentMetadata>()
-    servicingDataBuilder.docMetaList.forEach { documentMetadata ->
-        documentMetadata.checksum.takeIf { it.isSet() }?.checksum?.let { checksum ->
-            existingDocumentMetadata[checksum] = documentMetadata
-        }
-    }
+    val existingDocumentMetadata = servicingDataBuilder.docMetaList.toChecksumMap()
     val incomingDocumentChecksums = mutableMapOf<String, Boolean>()
     for (newDocument in newDocuments) {
         documentValidation(newDocument)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AddENoteAssumptionContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AddENoteAssumptionContractUnitTest.kt
@@ -1,0 +1,331 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.set
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuidSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidChecksum
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENote
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.breakOffLast
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.test.toPair
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.util.v1beta1.Checksum
+import tech.figure.util.v1beta1.DocumentMetadata
+
+class AddENoteAssumptionContractUnitTest : WordSpec({
+    "addAssumption" When {
+        val maxExistingAssumptionCount = (if (KotestConfig.runTestsExtended) 20 else 5)
+        "given an empty input" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidENote()) { randomExistingENote ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document is not set"
+                    }
+                }
+            }
+        }
+        "given an input with an invalid ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyInvalidUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomInvalidId, randomUri, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomInvalidId
+                                assumptionBuilder.checksum = randomChecksum
+                                assumptionBuilder.uri = randomUri
+                                assumptionBuilder.contentType = randomContentType
+                                assumptionBuilder.documentType = randomDocumentType
+                                assumptionBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document must have valid ID"
+                    }
+                }
+            }
+        }
+        "given an input without a valid checksum" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyNonEmptyString,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksumAlgorithm, randomId, randomUri, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomId
+                                assumptionBuilder.checksum = Checksum.newBuilder().also { checksumBuilder ->
+                                    checksumBuilder.clearChecksum()
+                                    checksumBuilder.algorithm = randomChecksumAlgorithm
+                                }.build()
+                                assumptionBuilder.uri = randomUri
+                                assumptionBuilder.contentType = randomContentType
+                                assumptionBuilder.documentType = randomDocumentType
+                                assumptionBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} must have a valid checksum string"
+                    }
+                }
+            }
+        }
+        "given an input without a URI" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomId
+                                assumptionBuilder.checksum = randomChecksum
+                                assumptionBuilder.contentType = randomContentType
+                                assumptionBuilder.documentType = randomDocumentType
+                                assumptionBuilder.fileName = randomFileName
+                                assumptionBuilder.clearUri()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing URI"
+                    }
+                }
+            }
+        }
+        "given an input without a content type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomUri, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomId
+                                assumptionBuilder.checksum = randomChecksum
+                                assumptionBuilder.uri = randomUri
+                                assumptionBuilder.documentType = randomDocumentType
+                                assumptionBuilder.fileName = randomFileName
+                                assumptionBuilder.clearContentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing content type"
+                    }
+                }
+            }
+        }
+        "given an input without a document type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomUri, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomId
+                                assumptionBuilder.checksum = randomChecksum
+                                assumptionBuilder.contentType = randomContentType
+                                assumptionBuilder.uri = randomUri
+                                assumptionBuilder.fileName = randomFileName
+                                assumptionBuilder.clearDocumentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing document type"
+                    }
+                }
+            }
+        }
+        "given an input without a file name" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomDocumentType, randomUri ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = randomExistingENote,
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = randomId
+                                assumptionBuilder.checksum = randomChecksum
+                                assumptionBuilder.contentType = randomContentType
+                                assumptionBuilder.documentType = randomDocumentType
+                                assumptionBuilder.uri = randomUri
+                                assumptionBuilder.clearFileName()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing file name"
+                    }
+                }
+            }
+        }
+        "given an input which attempts to silently change properties of an existing assumption" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    Arb.int(min = 1, max = maxExistingAssumptionCount).flatMap { documentCount ->
+                        anyValidENote(assumptionCount = documentCount)
+                    },
+                    anyValidChecksum,
+                    anyUuidSet(size = 2).toPair(),
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    anyNonEmptyString,
+                ) { eNote, checksum, (oldId, newId), (oldAl, newAl), (oldUri, newUri), (oldCType, newCType), (oldDType, newDType), randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteAssumptionContract(
+                            existingENote = eNote.toBuilder().also { existingENoteBuilder ->
+                                existingENoteBuilder.addAssumption(
+                                    DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                        assumptionBuilder.id = oldId
+                                        assumptionBuilder.checksum = checksum.toBuilder().also { checksumBuilder ->
+                                            checksumBuilder.algorithm = oldAl
+                                        }.build()
+                                        assumptionBuilder.contentType = oldCType
+                                        assumptionBuilder.documentType = oldDType
+                                        assumptionBuilder.fileName = randomFileName
+                                        assumptionBuilder.uri = oldUri
+                                    }.build()
+                                )
+                            }.build(),
+                        ).addAssumption(
+                            DocumentMetadata.newBuilder().also { assumptionBuilder ->
+                                assumptionBuilder.id = newId
+                                assumptionBuilder.checksum = checksum.toBuilder().also { checksumBuilder ->
+                                    checksumBuilder.algorithm = newAl
+                                }.build()
+                                assumptionBuilder.contentType = newCType
+                                assumptionBuilder.documentType = newDType
+                                assumptionBuilder.uri = newUri
+                                assumptionBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 5
+                        listOf("checksum algorithm", "ID", "URI", "content type", "document type").forEach { immutableField ->
+                            exception.message shouldContain
+                                "Cannot change $immutableField of existing document with checksum ${checksum.checksum}"
+                        }
+                    }
+                }
+            }
+        }
+        "given an input which duplicates an existing assumption's properties with the exception of the file name" should {
+            // TODO: Revisit this behavior in the future
+            "be added to the list without removing the existing assumption" {
+                checkAll(
+                    anyValidENote(assumptionCount = 0),
+                    Arb.int(min = 1, max = maxExistingAssumptionCount).flatMap { documentCount ->
+                        anyValidDocumentSet(size = documentCount)
+                    },
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomExistingAssumptions, randomFileName ->
+                    AddENoteAssumptionContract(
+                        existingENote = randomExistingENote.toBuilder().also { existingENoteBuilder ->
+                            existingENoteBuilder.addAllAssumption(randomExistingAssumptions)
+                        }.build(),
+                    ).addAssumption(
+                        randomExistingAssumptions.takeLast(1)[0].toBuilder().also { newAssumptionBuilder ->
+                            newAssumptionBuilder.fileName = randomFileName
+                        }.build()
+                    ).let { updatedENote ->
+                        updatedENote.assumptionCount shouldBe randomExistingAssumptions.size + 1
+                        updatedENote.assumptionList.last().fileName shouldBe randomFileName
+                    }
+                }
+            }
+        }
+        "given a valid input with a completely unique assumption" should {
+            "not throw an exception" {
+                checkAll(
+                    anyValidENote(assumptionCount = 0),
+                    Arb.int(min = 1, max = maxExistingAssumptionCount).flatMap { documentCount ->
+                        anyValidDocumentSet(size = documentCount)
+                    },
+                ) { randomExistingENote, randomAssumptions, ->
+                    val (existingAssumptions, newAssumption) = randomAssumptions.breakOffLast()
+                    AddENoteAssumptionContract(
+                        existingENote = randomExistingENote.toBuilder().also { existingENoteBuilder ->
+                            existingENoteBuilder.addAllAssumption(existingAssumptions)
+                        }.build(),
+                    ).addAssumption(
+                        newAssumption
+                    ).let { updatedENote ->
+                        updatedENote.assumptionCount shouldBe randomAssumptions.size
+                        updatedENote.assumptionList.last() shouldBe newAssumption
+                    }
+                }
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AddENoteModificationContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AddENoteModificationContractUnitTest.kt
@@ -1,0 +1,331 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.set
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuidSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidChecksum
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentSet
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidENote
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonEmptyString
+import io.provenance.scope.loan.test.breakOffLast
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.test.toPair
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.util.v1beta1.DocumentMetadata
+import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
+
+class AddENoteModificationContractUnitTest : WordSpec({
+    "addModification" When {
+        val maxExistingModificationCount = (if (KotestConfig.runTestsExtended) 20 else 5)
+        "given an empty input" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidENote()) { randomExistingENote ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document is not set"
+                    }
+                }
+            }
+        }
+        "given an input with an invalid ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyInvalidUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomInvalidId, randomUri, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomInvalidId
+                                modificationBuilder.checksum = randomChecksum
+                                modificationBuilder.uri = randomUri
+                                modificationBuilder.contentType = randomContentType
+                                modificationBuilder.documentType = randomDocumentType
+                                modificationBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document must have valid ID"
+                    }
+                }
+            }
+        }
+        "given an input without a valid checksum" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyNonEmptyString,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksumAlgorithm, randomId, randomUri, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomId
+                                modificationBuilder.checksum = FigureTechChecksum.newBuilder().also { checksumBuilder ->
+                                    checksumBuilder.clearChecksum()
+                                    checksumBuilder.algorithm = randomChecksumAlgorithm
+                                }.build()
+                                modificationBuilder.uri = randomUri
+                                modificationBuilder.contentType = randomContentType
+                                modificationBuilder.documentType = randomDocumentType
+                                modificationBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} must have a valid checksum string"
+                    }
+                }
+            }
+        }
+        "given an input without a URI" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomId
+                                modificationBuilder.checksum = randomChecksum
+                                modificationBuilder.contentType = randomContentType
+                                modificationBuilder.documentType = randomDocumentType
+                                modificationBuilder.fileName = randomFileName
+                                modificationBuilder.clearUri()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing URI"
+                    }
+                }
+            }
+        }
+        "given an input without a content type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomUri, randomDocumentType, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomId
+                                modificationBuilder.checksum = randomChecksum
+                                modificationBuilder.uri = randomUri
+                                modificationBuilder.documentType = randomDocumentType
+                                modificationBuilder.fileName = randomFileName
+                                modificationBuilder.clearContentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing content type"
+                    }
+                }
+            }
+        }
+        "given an input without a document type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomUri, randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomId
+                                modificationBuilder.checksum = randomChecksum
+                                modificationBuilder.contentType = randomContentType
+                                modificationBuilder.uri = randomUri
+                                modificationBuilder.fileName = randomFileName
+                                modificationBuilder.clearDocumentType()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing document type"
+                    }
+                }
+            }
+        }
+        "given an input without a file name" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidENote(),
+                    anyValidChecksum,
+                    anyUuid,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomChecksum, randomId, randomContentType, randomDocumentType, randomUri ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = randomExistingENote,
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = randomId
+                                modificationBuilder.checksum = randomChecksum
+                                modificationBuilder.contentType = randomContentType
+                                modificationBuilder.documentType = randomDocumentType
+                                modificationBuilder.uri = randomUri
+                                modificationBuilder.clearFileName()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Document with ID ${randomId.value} is missing file name"
+                    }
+                }
+            }
+        }
+        "given an input which attempts to silently change properties of an existing modification" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    Arb.int(min = 1, max = maxExistingModificationCount).flatMap { documentCount ->
+                        anyValidENote(modificationCount = documentCount)
+                    },
+                    anyValidChecksum,
+                    anyUuidSet(size = 2).toPair(),
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    Arb.set(gen = anyNonEmptyString, size = 2).toPair { set -> set.toList() },
+                    anyNonEmptyString,
+                ) { eNote, checksum, (oldId, newId), (oldAl, newAl), (oldUri, newUri), (oldCType, newCType), (oldDType, newDType), randomFileName ->
+                    shouldThrow<ContractViolationException> {
+                        AddENoteModificationContract(
+                            existingENote = eNote.toBuilder().also { existingENoteBuilder ->
+                                existingENoteBuilder.addModification(
+                                    DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                        modificationBuilder.id = oldId
+                                        modificationBuilder.checksum = checksum.toBuilder().also { checksumBuilder ->
+                                            checksumBuilder.algorithm = oldAl
+                                        }.build()
+                                        modificationBuilder.contentType = oldCType
+                                        modificationBuilder.documentType = oldDType
+                                        modificationBuilder.fileName = randomFileName
+                                        modificationBuilder.uri = oldUri
+                                    }.build()
+                                )
+                            }.build(),
+                        ).addModification(
+                            DocumentMetadata.newBuilder().also { modificationBuilder ->
+                                modificationBuilder.id = newId
+                                modificationBuilder.checksum = checksum.toBuilder().also { checksumBuilder ->
+                                    checksumBuilder.algorithm = newAl
+                                }.build()
+                                modificationBuilder.contentType = newCType
+                                modificationBuilder.documentType = newDType
+                                modificationBuilder.uri = newUri
+                                modificationBuilder.fileName = randomFileName
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 5
+                        listOf("checksum algorithm", "ID", "URI", "content type", "document type").forEach { immutableField ->
+                            exception.message shouldContain
+                                "Cannot change $immutableField of existing document with checksum ${checksum.checksum}"
+                        }
+                    }
+                }
+            }
+        }
+        "given an input which duplicates an existing modification's properties with the exception of the file name" should {
+            // TODO: Revisit this behavior in the future
+            "be added to the list without removing the existing modification" {
+                checkAll(
+                    anyValidENote(modificationCount = 0),
+                    Arb.int(min = 1, max = maxExistingModificationCount).flatMap { documentCount ->
+                        anyValidDocumentSet(size = documentCount)
+                    },
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomExistingModifications, randomFileName ->
+                    AddENoteModificationContract(
+                        existingENote = randomExistingENote.toBuilder().also { existingENoteBuilder ->
+                            existingENoteBuilder.addAllModification(randomExistingModifications)
+                        }.build(),
+                    ).addModification(
+                        randomExistingModifications.takeLast(1)[0].toBuilder().also { newModificationBuilder ->
+                            newModificationBuilder.fileName = randomFileName
+                        }.build()
+                    ).let { updatedENote ->
+                        updatedENote.modificationCount shouldBe randomExistingModifications.size + 1
+                        updatedENote.modificationList.last().fileName shouldBe randomFileName
+                    }
+                }
+            }
+        }
+        "given a valid input with a completely unique modification" should {
+            "not throw an exception" {
+                checkAll(
+                    anyValidENote(modificationCount = 0),
+                    Arb.int(min = 1, max = maxExistingModificationCount).flatMap { documentCount ->
+                        anyValidDocumentSet(size = documentCount)
+                    },
+                ) { randomExistingENote, randomModifications, ->
+                    val (existingModifications, newModification) = randomModifications.breakOffLast()
+                    AddENoteModificationContract(
+                        existingENote = randomExistingENote.toBuilder().also { existingENoteBuilder ->
+                            existingENoteBuilder.addAllModification(existingModifications)
+                        }.build(),
+                    ).addModification(
+                        newModification
+                    ).let { updatedENote ->
+                        updatedENote.modificationCount shouldBe randomModifications.size
+                        updatedENote.modificationList.last() shouldBe newModification
+                    }
+                }
+            }
+        }
+    }
+})

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -402,17 +402,16 @@ internal object MetadataAssetModelArbs {
             }
         }
     fun anyValidENote(
-        minAssumptionCount: Int = 0,
-        maxAssumptionCount: Int = 10,
-        minModificationCount: Int = 0,
-        maxModificationCount: Int = 10,
+        assumptionCount: Int = 0,
+        modificationCount: Int = 0,
+        slippage: Int = 10,
     ): Arb<ENote> = Arb.bind(
         anyValidENoteController,
         anyValidDocumentMetadata,
         anyPastNonEpochDate,
         PrimitiveArbs.anyNonEmptyString,
-        Arb.list(anyValidDocumentMetadata, range = minModificationCount..maxModificationCount),
-        Arb.list(anyValidDocumentMetadata, range = minAssumptionCount..maxAssumptionCount),
+        anyValidDocumentSet(size = assumptionCount, slippage = slippage),
+        anyValidDocumentSet(size = modificationCount, slippage = slippage),
     ) { controller, document, signedDate, vaultName, modifications, assumptions ->
         ENote.newBuilder().also { eNoteBuilder ->
             eNoteBuilder.controller = controller
@@ -479,14 +478,14 @@ internal object MetadataAssetModelArbs {
         }
     }
     inline fun <reified T : Message> anyValidLoan(
-        maxAssumptionCount: Int = 0,
-        maxModificationCount: Int = 0,
+        assumptionCount: Int = 0,
+        modificationCount: Int = 0,
         loanStateCount: Int = 3,
         iterationCount: Int = 3,
         loanDocumentCount: Int = 3,
     ): Arb<LoanPackage> = Arb.bind(
         anyValidAsset<T>(),
-        anyValidENote(maxAssumptionCount = maxAssumptionCount, maxModificationCount = maxModificationCount),
+        anyValidENote(assumptionCount = assumptionCount, modificationCount = modificationCount),
         anyValidServicingRights,
         anyValidServicingData(loanStateCount = loanStateCount),
         anyValidValidationRecord(iterationCount = iterationCount),
@@ -594,7 +593,7 @@ internal fun <T> List<T>.breakOffLast(): Pair<List<T>, T> {
     require(isNotEmpty()) {
         "Must supply a list with at least one element"
     }
-    return dropLast(1) to takeLast(1)[0]
+    return dropLast(1) to last()
 }
 
 internal fun <T> Arb<List<T>>.toPair(): Arb<Pair<T, T>> = map { list -> list[0] to list[1] }


### PR DESCRIPTION
## Context
This adds support for adding eNote modifications and/or assumptions _after_ the eNote record has been initialized in the scope. The two new contracts are meant to be invoked by the loan's servicer or subservicer, but will currently designate the owner as the invoker to work around persisting p8e party type limitations.
## Changes
### Major
- Define new contracts `AddENoteModificationContract` and `AddENoteAssumptionContract`
### Minor
- Require all `DocumentMetadata` and `ENote` inputs to specify the `fileName` field
### Patch
- Adjust eNote test helper logic for modification and assumption documents accordingly
- DRY some of the checksum-building logic
#### Non-breaking but important related updates
- Change `documentModificationValidation` function to return a `Boolean` indicating if the new input document duplicates the existing document, in foresight of potentially adjusting how duplicate documents are handled in the future
- Update code comments
