### PR TITLE
Set proper workflow concurrencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ on:
         default: true
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.chain_id }}
+  cancel-in-progress: true
+
 jobs:
   build-and-publish:
     name: Build and Publish Jar


### PR DESCRIPTION
## Changes
### Patch
- Set build workflow concurrency with cancellation so that it cancels in-progress runs [for the same workflow on the same branch](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow)
- Add deploy workflow concurrency with cancellation so that there can be at most one active per public chain (environment)