### PR TITLE
Update Money protobuf validation to use string value

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,6 @@ disabled_rules=filename
 [contract/**/contracts/*.kt]
 disabled_rules=wrapping,no-multi-spaces
 [contract/**/utility/LoanContractValidations.kt]
-disabled_rules=wrapping,no-multi-spaces
+disabled_rules=no-multi-spaces
+[contract/**/utility/DataValidationExtensions.kt]
+disabled_rules=no-multi-spaces

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
         const val JacksonProtobuf = "0.9.12"
         object Provenance {
             const val Scope = "0.6.2"
-            const val MetadataAssetModel = "0.1.11"
+            const val MetadataAssetModel = "0.1.12"
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
@@ -9,7 +9,6 @@ import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.validation.v1beta1.ValidationRequest
 import tech.figure.validation.v1beta1.ValidationResults
 import io.dartinc.registry.v1beta1.Controller as ENoteController
-import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 
 internal fun ContractEnforcementContext.documentModificationValidation(
     existingDocument: DocumentMetadata,
@@ -36,15 +35,6 @@ internal fun ContractEnforcementContext.documentModificationValidation(
             )
         }
     }
-}
-
-internal fun ContractEnforcementContext.checksumValidation(parentDescription: String = "Input", checksum: FigureTechChecksum) {
-    checksum.takeIf { it.isSet() }?.let { setChecksum ->
-        requireThat(
-            setChecksum.checksum.isNotBlank()  orError "$parentDescription must have a valid checksum string",
-            setChecksum.algorithm.isNotBlank() orError "$parentDescription must specify a checksum algorithm",
-        )
-    } ?: raiseError("$parentDescription's checksum is not set")
 }
 
 internal val documentValidation: ContractEnforcementContext.(DocumentMetadata) -> Unit = { document ->


### PR DESCRIPTION
## Context
Updating the contracts to [the latest version of metadata-asset-model](https://github.com/provenance-io/metadata-asset-model/compare/v0.1.11...v0.1.12) per the changes made in https://github.com/provenance-io/metadata-asset-model/pull/15
## Changes
### Patch
- Update `metadata-asset-model` from `0.1.11` to `0.1.12`
- Change `tech.figure.util.v1beta1.Money` validation to validate the new string field over the deprecated double field
- Add forgotten validation of currency field
- Refactor the corresponding validation method to provide more specific exceptions
- Adjust signature and file location of similar checksum validation method
## Notes
- Currently, the only contracts here that _could_ make use of the Money validation are ones which update the top-level fields of the `ServicingData` record. However, the loan scope and its contracts are still in beta and being influenced by initial use cases, so `ServicingData.originalNoteAmount` does not undergo any validation as of this version.