### PR TITLE
Enable convenient servicing record document uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To generate linting reports, use
 ```shell
 ./gradlew ktlintCheck
 ```
-To have the linter update your code to fit the linting rules, use
+To have the linter try to update your code to fit the linting rules, use
 ```shell
 ./gradlew ktlintFormat
 ```

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
         const val JacksonProtobuf = "0.9.12"
         object Provenance {
             const val Scope = "0.6.2"
-            const val MetadataAssetModel = "0.1.12"
+            const val MetadataAssetModel = "0.1.13"
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -37,6 +37,11 @@ object LoanScopeProperties {
      * [tech.figure.loan.v1beta1.MISMOLoanMetadata].
      */
     const val assetMismoKey = "mismoLoan"
+    /**
+     * Denotes the key that a [LoanDocuments][tech.figure.loan.v1beta1.LoanDocuments] instance's `metadataKvMap` should use to store a
+     * [DocumentRecordingGuidance][io.dartinc.registry.v1beta1.DocumentRecordingGuidance] pertaining to servicing documents.
+     */
+    const val servicingDocumentsKey = "servicingDocuments"
 }
 
 /**

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
@@ -1,5 +1,6 @@
 package io.provenance.scope.loan.contracts
 
+import io.dartinc.registry.v1beta1.DocumentRecordingGuidance
 import io.provenance.scope.contract.annotations.Function
 import io.provenance.scope.contract.annotations.Input
 import io.provenance.scope.contract.annotations.Participants
@@ -8,18 +9,24 @@ import io.provenance.scope.contract.annotations.ScopeSpecification
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeProperties.servicingDocumentsKey
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.documentModificationValidation
 import io.provenance.scope.loan.utility.documentValidation
+import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.raiseError
+import io.provenance.scope.loan.utility.unpackOrNull
+import io.provenance.scope.loan.utility.updateServicingData
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.loan.v1beta1.LoanDocuments
+import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.util.v1beta1.DocumentMetadata
 
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
 open class AppendLoanDocumentsContract(
     @Record(name = LoanScopeFacts.documents, optional = true) val existingDocs: LoanDocuments?,
+    @Record(name = LoanScopeFacts.servicingData, optional = true) val existingServicingData: ServicingData?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER)
@@ -58,5 +65,27 @@ open class AppendLoanDocumentsContract(
             }
         }
         return newDocList.build()
+    }
+
+    @Function(invokedBy = PartyType.OWNER)
+    @Record(LoanScopeFacts.servicingData)
+    open fun appendServicingDocuments(@Input(LoanScopeFacts.documents) newDocs: LoanDocuments): ServicingData {
+        return newDocs.metadataKvMap[servicingDocumentsKey]?.unpackOrNull<DocumentRecordingGuidance>()?.let { servicingDocumentGuidance ->
+            ServicingData.newBuilder().also { servicingDataBuilder ->
+                servicingDataBuilder.addAllDocMeta(
+                    newDocs.documentList.filter { document ->
+                        document.id.isSet() && servicingDocumentGuidance.containsDesignatedDocuments(document.id.value)
+                    }
+                )
+            }.build()
+        }?.let { wrappedServicingDocuments ->
+            validateRequirements(VALID_INPUT) {
+                updateServicingData(
+                    existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
+                    newServicingData = wrappedServicingDocuments,
+                    expectLoanStates = false,
+                )
+            }
+        } ?: existingServicingData ?: ServicingData.getDefaultInstance()
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanStatesContract.kt
@@ -9,7 +9,9 @@ import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.updateServicingData
+import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateSubmission
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 
@@ -22,10 +24,13 @@ open class AppendLoanStatesContract(
     @Function(invokedBy = PartyType.SERVICER)
     @Record(LoanScopeFacts.servicingData)
     open fun appendLoanStates(@Input(LoanScopeInputs.newLoanStates) newLoanStates: LoanStateSubmission): ServicingData =
-        updateServicingData(
-            existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
-            newServicingData = ServicingData.newBuilder().also { incomingBuilder ->
-                incomingBuilder.addAllLoanState(newLoanStates.loanStateList)
-            }.build(),
-        )
+        validateRequirements(VALID_INPUT) {
+            updateServicingData(
+                existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
+                newServicingData = ServicingData.newBuilder().also { incomingBuilder ->
+                    incomingBuilder.addAllLoanState(newLoanStates.loanStateList)
+                }.build(),
+                expectLoanStates = true,
+            )
+        }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordENoteContract.kt
@@ -10,8 +10,10 @@ import io.provenance.scope.contract.annotations.SkipIfRecordExists
 import io.provenance.scope.contract.proto.Specifications.PartyType
 import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.eNoteInputValidation
 import io.provenance.scope.loan.utility.updateServicingData
+import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 
 @Participants(roles = [PartyType.OWNER])
@@ -30,5 +32,7 @@ open class RecordENoteContract(
     @Record(LoanScopeFacts.servicingData)
     @SkipIfRecordExists(LoanScopeFacts.servicingData)
     open fun recordServicingData(@Input(LoanScopeFacts.servicingData) newServicingData: ServicingData): ServicingData =
-        updateServicingData(newServicingData = newServicingData)
+        validateRequirements(VALID_INPUT) {
+            updateServicingData(newServicingData = newServicingData)
+        }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -116,10 +116,12 @@ open class RecordLoanContract(
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.servicingData)
     open fun recordServicingData(@Input(LoanScopeFacts.servicingData) servicingData: ServicingData) =
-        updateServicingData(
-            existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
-            newServicingData = servicingData,
-        )
+        validateRequirements(VALID_INPUT) {
+            updateServicingData(
+                existingServicingData = existingServicingData ?: ServicingData.getDefaultInstance(),
+                newServicingData = servicingData,
+            )
+        }
 
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.loanValidations)

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -63,7 +63,7 @@ open class RecordLoanContract(
             }
             if (newAsset.containsKv(assetLoanKey) xor newAsset.containsKv(assetMismoKey)) {
                 newAsset.kvMap[assetLoanKey]?.let { newLoanValue ->
-                    newLoanValue.tryUnpackingAs<FigureTechLoan>("input asset's \"${assetLoanKey}\"") { newLoan ->
+                    newLoanValue.tryUnpackingAs<FigureTechLoan, Unit>("input asset's \"${assetLoanKey}\"") { newLoan ->
                         if (existingAsset.isSet()) {
                             existingAsset!!.kvMap[assetLoanKey]?.toFigureTechLoan()?.also { existingLoan ->
                                 requireThat(
@@ -82,7 +82,7 @@ open class RecordLoanContract(
                     }
                 }
                 newAsset.kvMap[assetMismoKey]?.let { newLoanValue ->
-                    newLoanValue.tryUnpackingAs<MISMOLoanMetadata>("input asset's \"${assetMismoKey}\"") { newLoan ->
+                    newLoanValue.tryUnpackingAs<MISMOLoanMetadata, Unit>("input asset's \"${assetMismoKey}\"") { newLoan ->
                         documentValidation(newLoan.document)
                         if (existingAsset.isSet()) {
                             existingAsset!!.kvMap[assetMismoKey]?.toMISMOLoan()?.also { existingLoan ->

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -84,14 +84,18 @@ internal fun validateRequirements(
  * Should be used to wrap code bodies that also performs actions other than validation.
  *
  * @param requirementType The type of validation being performed.
- * @param checksBody a body of code which contains calls to [ContractEnforcementContext.requireThat].
+ * @param checksBody A body of code which contains calls to [ContractEnforcementContext.requireThat].
  */
-internal fun validateRequirements(
+internal fun <T> validateRequirements(
     requirementType: ContractRequirementType,
-    checksBody: ContractEnforcementContext.() -> Unit,
-) = ContractEnforcementContext(requirementType)
-    .apply(checksBody)
-    .handleViolations()
+    checksBody: ContractEnforcementContext.() -> T,
+): T {
+    with(ContractEnforcementContext(requirementType)) {
+        val result = checksBody()
+        handleViolations()
+        return result
+    }
+}
 
 /**
  * Aggregates multiple [ContractEnforcement]s into a single exception listing all of the [ContractViolation]s that

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/ContractRequirements.kt
@@ -85,6 +85,8 @@ internal fun validateRequirements(
  *
  * @param requirementType The type of validation being performed.
  * @param checksBody A body of code which contains calls to [ContractEnforcementContext.requireThat].
+ * @throws Exception if at least one violation was collected in [checksBody].
+ * @return The result of [checksBody], if no violations were collected.
  */
 internal fun <T> validateRequirements(
     requirementType: ContractRequirementType,

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
@@ -7,9 +7,9 @@ import com.google.protobuf.Any as ProtobufAny
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 
 context(ContractEnforcementContext)
-internal inline fun <reified T : Message> ProtobufAny.tryUnpackingAs(inputDescription: String = "input", body: (T) -> Any) {
-    val expectedType = T::class.java
-    var unpackedResult: T? = null
+internal inline fun <reified M : Message, S> ProtobufAny.tryUnpackingAs(inputDescription: String = "input", body: (M) -> S): S? {
+    val expectedType = M::class.java
+    var unpackedResult: M? = null
     try {
         unpackedResult = unpack(expectedType)
     } catch (suppressed: InvalidProtocolBufferException) {
@@ -38,8 +38,10 @@ internal inline fun <reified T : Message> ProtobufAny.tryUnpackingAs(inputDescri
             raiseError(violationMessage)
         }
     }
-    if (unpackedResult !== null) {
+    return if (unpackedResult !== null) {
         body(unpackedResult)
+    } else {
+        null
     }
 }
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
@@ -43,6 +43,15 @@ internal inline fun <reified T : Message> ProtobufAny.tryUnpackingAs(inputDescri
     }
 }
 
+internal inline fun <reified T : Message> ProtobufAny.unpackOrNull(): T? =
+    T::class.java.let { clazz ->
+        try {
+            unpack(clazz)
+        } catch (suppressed: InvalidProtocolBufferException) {
+            null
+        }
+    }
+
 internal inline fun <reified T : Message> ProtobufAny.unpackAs(): T =
     T::class.java.let { clazz ->
         try {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -449,10 +449,10 @@ internal object MetadataAssetModelArbs {
                 documentsBuilder.addAllDocument(documentList)
             }.build()
         }
-    fun anyValidServicingData(loanStateCount: Int, slippage: Int = 10): Arb<ServicingData> =
+    fun anyValidServicingData(loanStateAndDocumentCount: Int, slippage: Int = 10): Arb<ServicingData> =
         Arb.bind(
-            anyValidDocumentSet(size = loanStateCount, slippage = slippage),
-            loanStateSet(size = loanStateCount, slippage = slippage),
+            anyValidDocumentSet(size = loanStateAndDocumentCount, slippage = slippage),
+            loanStateSet(size = loanStateAndDocumentCount, slippage = slippage),
         ) { documents, loanStates ->
             ServicingData.newBuilder().also { servicingDataBuilder ->
                 servicingDataBuilder.clearDocMeta()
@@ -496,7 +496,7 @@ internal object MetadataAssetModelArbs {
         anyValidAsset<T>(),
         anyValidENote(maxAssumptionCount = maxAssumptionCount, maxModificationCount = maxModificationCount),
         anyValidServicingRights,
-        anyValidServicingData(loanStateCount = loanStateCount),
+        anyValidServicingData(loanStateAndDocumentCount = loanStateCount),
         anyValidValidationRecord(iterationCount = iterationCount),
         anyValidLoanDocumentSet(size = loanDocumentCount),
     ) { randomAsset, randomENote, randomServicingRights, randomServicingData, randomValidationRecord, randomLoanDocuments ->

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -444,10 +444,7 @@ internal object MetadataAssetModelArbs {
     }
     fun anyValidLoanDocumentSet(size: Int, slippage: Int = 10): Arb<LoanDocuments> =
         anyValidDocumentSet(size = size, slippage = slippage).map { documentList ->
-            LoanDocuments.newBuilder().also { documentsBuilder ->
-                documentsBuilder.clearDocument()
-                documentsBuilder.addAllDocument(documentList)
-            }.build()
+            documentList.toRecord()
         }
     fun anyValidServicingData(loanStateAndDocumentCount: Int, slippage: Int = 10): Arb<ServicingData> =
         Arb.bind(

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -612,6 +612,13 @@ internal fun <T> List<T>.breakOffLast(): Pair<List<T>, T> {
     return dropLast(1) to takeLast(1)[0]
 }
 
+internal fun <T> List<T>.breakOffLast(split: Int): Pair<List<T>, List<T>> {
+    require(split in 0..size) {
+        "Must supply a valid split"
+    }
+    return dropLast(split) to takeLast(split)
+}
+
 internal fun <T> Arb<List<T>>.toPair(): Arb<Pair<T, T>> = map { list -> list[0] to list[1] }
 
 internal fun <S, T> Arb<S>.toPair(fn: (S) -> List<T>): Arb<Pair<T, T>> = map(fn).toPair()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -4,6 +4,8 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.ints.shouldBeLessThan
@@ -11,8 +13,12 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainIgnoringCase
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
 import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentMetadata
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingData
 import io.provenance.scope.loan.test.PrimitiveArbs
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 
@@ -141,6 +147,23 @@ class ContractRequirementsUnitTest : WordSpec({
                                 3 shouldBeLessThan 4
                             }
                         }
+                    }
+                }
+            }
+            "return the result of its body when no violations are raised" {
+                checkAll(
+                    Arb.int(min = 0, max = 6).flatMap { documentCount ->
+                        anyValidServicingData(loanStateAndDocumentCount = documentCount)
+                    },
+                    anyValidDocumentMetadata,
+                ) { randomServicingData, randomDocumentMetadata ->
+                    validateRequirements(ContractRequirementType.VALID_INPUT) {
+                        randomServicingData.toBuilder().also { servicingDataBuilder ->
+                            servicingDataBuilder.addDocMeta(randomDocumentMetadata)
+                        }.build()
+                    }.let { modifiedServicingData ->
+                        modifiedServicingData.docMetaCount shouldBeExactly randomServicingData.docMetaCount + 1
+                        modifiedServicingData.docMetaList shouldContain randomDocumentMetadata
                     }
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -4,7 +4,7 @@ import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCaseOrder
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBeInRange
@@ -163,7 +163,7 @@ class ContractRequirementsUnitTest : WordSpec({
                         }.build()
                     }.let { modifiedServicingData ->
                         modifiedServicingData.docMetaCount shouldBeExactly randomServicingData.docMetaCount + 1
-                        modifiedServicingData.docMetaList shouldContain randomDocumentMetadata
+                        modifiedServicingData.docMetaList shouldContainExactlyInAnyOrder randomServicingData.docMetaList + randomDocumentMetadata
                     }
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
@@ -43,9 +43,18 @@ class DataConversionExtensionsUnitTest : WordSpec({
             "not throw an exception" {
                 checkAll(anyUuid) { randomId ->
                     validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
-                        randomId.toProtoAny().tryUnpackingAs<FigureTechUUID> { unpacked ->
+                        randomId.toProtoAny().tryUnpackingAs<FigureTechUUID, Unit> { unpacked ->
                             unpacked shouldBe randomId
                         }
+                    }
+                }
+            }
+            "return the result of its body" {
+                checkAll(anyUuid) { randomId ->
+                    validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+                        randomId.toProtoAny().tryUnpackingAs<FigureTechUUID, Boolean> { unpacked ->
+                            unpacked.isValid()
+                        } shouldBe true
                     }
                 }
             }
@@ -55,7 +64,7 @@ class DataConversionExtensionsUnitTest : WordSpec({
                 checkAll(anyValidChecksum) { randomChecksum ->
                     shouldThrow<IllegalContractStateException> {
                         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
-                            randomChecksum.toProtoAny().tryUnpackingAs<FigureTechUUID> {}
+                            randomChecksum.toProtoAny().tryUnpackingAs<FigureTechUUID, Unit> {}
                         }
                     }.let { exception ->
                         exception.shouldBeParseFailureFor(classifier = "tech.figure.util.v1beta1.UUID")
@@ -68,7 +77,7 @@ class DataConversionExtensionsUnitTest : WordSpec({
                 checkAll(anyValidFigureTechLoan) { randomLoan ->
                     shouldThrow<IllegalContractStateException> {
                         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
-                            randomLoan.toProtoAny().tryUnpackingAs<MISMOLoanMetadata> {}
+                            randomLoan.toProtoAny().tryUnpackingAs<MISMOLoanMetadata, Unit> {}
                         }
                     }.let { exception ->
                         exception.message shouldContain
@@ -82,7 +91,7 @@ class DataConversionExtensionsUnitTest : WordSpec({
                 checkAll(anyValidMismoLoan) { randomLoan ->
                     shouldThrow<IllegalContractStateException> {
                         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
-                            randomLoan.toProtoAny().tryUnpackingAs<FigureTechLoan> {}
+                            randomLoan.toProtoAny().tryUnpackingAs<FigureTechLoan, Unit> {}
                         }
                     }.let { exception ->
                         exception.message shouldContain

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
@@ -77,7 +77,7 @@ class DataValidationUnitTest : WordSpec({
     "Timestamp.isValidAndNotInFuture" should {
         "return true for any date in the past" {
             forAll(
-                Arb.localDateTime(maxLocalDateTime = LocalDateTime.now()),
+                Arb.localDateTime(maxLocalDateTime = LocalDateTime.now().minusDays(1L)),
                 anyZoneOffset,
             ) { randomLocalDateTime, randomZoneOffset ->
                 randomLocalDateTime.atOffset(randomZoneOffset).toProtoTimestamp().isValidAndNotInFuture()


### PR DESCRIPTION
## Context
Both the `documents` and `servicingData` records are able to store collections of `DocumentMetadata`. It would be appropriate and convenient to enable the `AppendLoanDocumentsContract` to be able to
1. always add documents to the `documents` record as the dedicated record for any document which needs to be on a loan scope
2. copy desired documents, if any, to the `servicingData` record
## Changes
### Minor
- Add second function to `AppendLoanDocumentsContract` which acts on the same `documents` input key as the existing function, appending documents which have been marked in a very specific manner using a key-value pair with a map of document IDs to `servicingData`
- Fix bug caused by typo in `updateServicingData` function
### Patch
- Adjust `validateRequirements` helper function to return the result of its body when no violation exception is thrown
- Move and rename record string generation to more appropriate path
- Update record string generators to reflect the most commonly expected usages of optional Any types
- Fix a longstanding intermittent test failure concerning negative offsets of recent local dates
- Fix small phrasing in README
## Problems
- https://github.com/provenance-io/p8e-scope-sdk/ currently expects any function which has its required input supplied to return a non-nullable protobuf value. As a result, implementing the functionality desired results in the `servicingData` record getting initialized with a default instance (i.e. `{"docMeta":[],"loanState":[]}`) rather than remaining uninitialized as would be ideal. I suggest this flaw be permitted to be introduced in this PR with the reasoning that
  - Anyone looking at the details of the Provenance scope session which invoked the contract can reasonably be expected to be able to reference the contract's source code to understand the action that took place if they wish to
  - Anyone hydrating the scope should be able to plainly see that the record has no data

  Second opinions appreciated.