### PR TITLE
Validate eNote signatures & improve document and checksum checks

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -27,7 +27,7 @@ object Versions {
         const val JacksonProtobuf = "0.9.12"
         object Provenance {
             const val Scope = "0.6.2"
-            const val MetadataAssetModel = "0.1.13"
+            const val MetadataAssetModel = "0.1.14"
         }
     }
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataConversionExtensions.kt
@@ -3,8 +3,17 @@ package io.provenance.scope.loan.utility
 import com.google.protobuf.InvalidProtocolBufferException
 import com.google.protobuf.Message
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
+import tech.figure.util.v1beta1.DocumentMetadata
 import com.google.protobuf.Any as ProtobufAny
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
+
+internal fun Iterable<DocumentMetadata>.toChecksumMap(): Map<String, DocumentMetadata> = mutableMapOf<String, DocumentMetadata>().also { map ->
+    forEach { document ->
+        document.checksum.checksum.takeIf { it.isNotBlank() }?.let { checksum ->
+            map[checksum] = document
+        }
+    }
+}
 
 context(ContractEnforcementContext)
 internal inline fun <reified M : Message, S> ProtobufAny.tryUnpackingAs(inputDescription: String = "input", body: (M) -> S): S? {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
@@ -95,7 +95,7 @@ internal val eNoteValidation: ContractEnforcementContext.(ENote) -> Unit = { eNo
         val borrowerSignatureChecksums = mutableMapOf<String, Boolean>()
         eNote.borrowerSignatureImageList.forEach { signature ->
             documentValidation(signature)
-            signature.checksum.checksum?.let { newSignatureChecksum ->
+            signature.checksum.checksum.takeIf { it.isNotBlank() }?.let { newSignatureChecksum ->
                 if (borrowerSignatureChecksums[newSignatureChecksum] == true) {
                     raiseError("Borrower signature with checksum $newSignatureChecksum is provided more than once in input")
                 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateENoteContractUnitTest.kt
@@ -158,7 +158,8 @@ class UpdateENoteContractUnitTest : WordSpec({
                     anyNonEmptyString,
                     anyNonEmptyString,
                     anyNonEmptyString,
-                ) { randomExistingENote, randomId, randomUri, randomContentType, randomDocumentType, randomChecksumAlgorithm ->
+                    anyNonEmptyString,
+                ) { randomExistingENote, randomId, randomUri, randomContentType, randomDocumentType, randomFileName, randomChecksumAlgorithm ->
                     shouldThrow<ContractViolationException> {
                         UpdateENoteContract(
                             existingENote = randomExistingENote,
@@ -168,6 +169,7 @@ class UpdateENoteContractUnitTest : WordSpec({
                                 eNoteBuilder.uri = randomUri
                                 eNoteBuilder.contentType = randomContentType
                                 eNoteBuilder.documentType = randomDocumentType
+                                eNoteBuilder.fileName = randomFileName
                                 eNoteBuilder.checksum = FigureTechChecksum.newBuilder().also { checksumBuilder ->
                                     checksumBuilder.clearChecksum()
                                     checksumBuilder.algorithm = randomChecksumAlgorithm

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -414,6 +414,8 @@ internal object MetadataAssetModelArbs {
         maxAssumptionCount: Int = 10,
         minModificationCount: Int = 0,
         maxModificationCount: Int = 10,
+        minSignatureCount: Int = 0,
+        maxSignatureCount: Int = 10,
     ): Arb<ENote> = Arb.bind(
         anyValidENoteController,
         anyValidDocumentMetadata,
@@ -421,7 +423,8 @@ internal object MetadataAssetModelArbs {
         PrimitiveArbs.anyNonEmptyString,
         Arb.list(anyValidDocumentMetadata, range = minModificationCount..maxModificationCount),
         Arb.list(anyValidDocumentMetadata, range = minAssumptionCount..maxAssumptionCount),
-    ) { controller, document, signedDate, vaultName, modifications, assumptions ->
+        Arb.list(anyValidDocumentMetadata, range = minSignatureCount..maxSignatureCount),
+    ) { controller, document, signedDate, vaultName, modifications, assumptions, signatures ->
         ENote.newBuilder().also { eNoteBuilder ->
             eNoteBuilder.controller = controller
             eNoteBuilder.eNote = document
@@ -431,6 +434,8 @@ internal object MetadataAssetModelArbs {
             eNoteBuilder.addAllModification(modifications)
             eNoteBuilder.clearAssumption()
             eNoteBuilder.addAllAssumption(assumptions)
+            eNoteBuilder.clearBorrowerSignatureImage()
+            eNoteBuilder.addAllBorrowerSignatureImage(signatures)
         }.build()
     }
     val anyValidServicingRights: Arb<ServicingRights> = Arb.bind(


### PR DESCRIPTION
## Context
While we're adding validation for the new eNote borrower signature image document list, let's improve the contracts' overalll file checking logic.
## Changes
### Minor
- Require `fileName` field to not be empty in any `DocumentMetadata`
- Require that borrower signature images in an eNote recording are fully populated `DocumentMetadata`s with unique checksums among the input
- Fix duplicate checksums in input servicing documents not actually raising a violation
- Change duplicate checksum logic in a few places to only raise violations if the duplicate is not blank — the per-item validations can enforce the requirement separately, to reduce clutter in the resulting exception message