### PR TITLE
Allow skipping Maven publishing, remove full fetch from workflows [NO TICKET]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
         description: 'The version to publish'
         required: true
         type: string
+      skipMavenPublishing:
+        description: 'Skip publishing to Maven'
+        type: boolean
+        required: true
+        default: false
       publishing_environment:
         description: 'Environment to bootstrap the contracts to'
         required: true
@@ -53,7 +58,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
           ref: ${{ github.event.inputs.version }}
 
       - name: Set up JDK 11
@@ -81,6 +85,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
+        if: github.event.inputs.skipMavenPublishing == false
         run: |
           VERSION=$( echo ${{ github.event.inputs.version }} | sed -e 's/^v//' )
           ./gradlew publishToSonatype -Pversion="$VERSION" \


### PR DESCRIPTION
## Changes
- Allow skipping the publishing of Maven artifacts when running the release workflow, so that if a version which has already been bootstrapped to an environment (e.g. testnet) by a previous run can be bootstrapped to another environment (e.g. mainnet) without causing the workflow to fail when it finds that the Maven artifacts already exist
- Remove the `fetch-depth: 0` from the repository checkout steps, as they were only needed when we were previously using  a semver plugin to calculate a version — we have long since moved to using release drafter instead