### PR TITLE
Always require Figure Tech loan in Asset record & make MISMO metadata completely optional

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -13,7 +13,6 @@ import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeProperties.assetLoanKey
 import io.provenance.scope.loan.LoanScopeProperties.assetMismoKey
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
-import io.provenance.scope.loan.utility.documentModificationValidation
 import io.provenance.scope.loan.utility.documentValidation
 import io.provenance.scope.loan.utility.eNoteInputValidation
 import io.provenance.scope.loan.utility.isSet
@@ -24,7 +23,6 @@ import io.provenance.scope.loan.utility.orError
 import io.provenance.scope.loan.utility.raiseError
 import io.provenance.scope.loan.utility.servicingRightsInputValidation
 import io.provenance.scope.loan.utility.toFigureTechLoan
-import io.provenance.scope.loan.utility.toMISMOLoan
 import io.provenance.scope.loan.utility.tryUnpackingAs
 import io.provenance.scope.loan.utility.uliValidation
 import io.provenance.scope.loan.utility.updateServicingData
@@ -87,17 +85,6 @@ open class RecordLoanContract(
             newAsset.kvMap[assetMismoKey]?.let { newMismoLoanValue ->
                 newMismoLoanValue.tryUnpackingAs<MISMOLoanMetadata, Unit>("input asset's \"${assetMismoKey}\"") { newLoan ->
                     documentValidation(newLoan.document)
-                    if (existingAsset.isSet()) {
-                        existingAsset!!.kvMap[assetMismoKey]?.toMISMOLoan()?.also { existingLoan ->
-                            // TODO: Allow doc with different checksum to replace existing one or not?
-                            documentModificationValidation(existingLoan.document, newLoan.document)
-                            requireThat(
-                                (existingLoan.uli == newLoan.uli) orError "Cannot change loan ULI",
-                            )
-                        }
-                    } else {
-                        uliValidation(newLoan.uli)
-                    }
                 }
             }
         }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -70,12 +70,6 @@ open class RecordLoanContract(
                                     (existingLoan.id == newLoan.id)                         orError "Cannot change loan ID",
                                     (existingLoan.originatorName == newLoan.originatorName) orError "Cannot change loan originator name",
                                 )
-                            } ?: run {
-                                /**
-                                 * This violation breaks executions against loans which were onboarded as MISMO-only loans before
-                                 * support for MISMO-only loans was removed.
-                                 */
-                                raiseError("The input asset had key \"${assetLoanKey}\" but the existing asset did not")
                             }
                         } else {
                             requireThat(

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -70,7 +70,13 @@ open class RecordLoanContract(
                                     (existingLoan.id == newLoan.id)                         orError "Cannot change loan ID",
                                     (existingLoan.originatorName == newLoan.originatorName) orError "Cannot change loan originator name",
                                 )
-                            } ?: raiseError("The input asset had key \"${assetLoanKey}\" but the existing asset did not")
+                            } ?: run {
+                                /**
+                                 * This violation breaks executions against loans which were onboarded as MISMO-only loans before
+                                 * support for MISMO-only loans was removed.
+                                 */
+                                raiseError("The input asset had key \"${assetLoanKey}\" but the existing asset did not")
+                            }
                         } else {
                             requireThat(
                                 newLoan.id.isValid()                orError "Loan must have valid ID",

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
@@ -16,9 +16,7 @@ import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidLoanDocument
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingData
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingRights
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationRecord
-import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.proto.util.toProtoAny
-import tech.figure.loan.v1beta1.Loan as FigureTechLoan
 
 @Ignored
 internal class TestDataGenerators : WordSpec({
@@ -30,8 +28,8 @@ internal class TestDataGenerators : WordSpec({
     val randomSource = RandomSource.default()
     /* JSON generators */
     "KotestHelpers" should {
-        "be able to generate a random fully populated Figure Tech loan scope" {
-            anyValidLoan<FigureTechLoan>().next(randomSource).let { randomLoanPackage ->
+        "be able to generate a random fully populated loan scope without a MISMO loan" {
+            anyValidLoan(hasMismoLoan = false).next(randomSource).let { randomLoanPackage ->
                 println(
                     mapper.writeValueAsString(
                         mapOf(
@@ -46,8 +44,8 @@ internal class TestDataGenerators : WordSpec({
                 )
             }
         }
-        "be able to generate a random fully populated MISMO loan scope" {
-            anyValidLoan<MISMOLoanMetadata>().next(randomSource).let { randomLoanPackage ->
+        "be able to generate a random fully populated loan scope with a MISMO loan" {
+            anyValidLoan(hasMismoLoan = true).next(randomSource).let { randomLoanPackage ->
                 println(
                     mapper.writeValueAsString(
                         mapOf(
@@ -64,12 +62,12 @@ internal class TestDataGenerators : WordSpec({
         }
         "be able to generate a random asset for a Figure Tech loan" {
             println(
-                mapper.writeValueAsString(anyValidAsset<FigureTechLoan>().next(randomSource))
+                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = false).next(randomSource))
             )
         }
-        "be able to generate a random asset for a MISMO loan" {
+        "be able to generate a random asset for a Figure Tech loan with a MISMO loan" {
             println(
-                mapper.writeValueAsString(anyValidAsset<MISMOLoanMetadata>().next(randomSource))
+                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = true).next(randomSource))
             )
         }
         "be able to generate a random eNote" {


### PR DESCRIPTION
## Context
To better suit current usecases of the `metadata-asset-model`, this requires all assets to have a Figure Tech loan but allows for any asset to also have an optional MISMO loan metadata object in the same key-value entry as before.
## Changes
- Require all Asset records to have a Figure Tech loan in the same key-value pair as before
- Remove support for Asset records with a MISMO loan metadata but no Figure Tech loan
- Allow the MISMO loan metadata in an Asset record to be added or removed when executing RecordLoanContract at any record state