### PR TITLE
Update metadata-asset-model to v1, further polish the README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 Defines a loan package scope specification and [p8e](https://github.com/provenance-io/p8e-scope-sdk/)
 smart contracts that can be executed against it.
 ## Status
+[![Build][build-badge]][build-workflow]
 [![stability-beta][stability-badge]][stability-info]
 [![Code Coverage][code-coverage-badge]][code-coverage-report]
-[![Latest Release][release-badge]][release-latest]
-
 [![LOC][loc-badge]][loc-url]
 ### Artifacts
+[![Latest Release][release-badge]][release-latest]
 #### Contracts JAR
 [![Contracts Artifact][contracts-publication-badge]][contracts-publication-url]
 #### Protobuf JAR
 [![Proto Artifact][proto-publication-badge]][proto-publication-url]
 
+[build-badge]: https://img.shields.io/github/actions/workflow/status/provenance-io/loan-package-contracts/build.yml?branch=main&style=for-the-badge
+[build-workflow]: https://github.com/provenance-io/loan-package-contracts/actions/workflows/build.yml
 [stability-badge]: https://img.shields.io/badge/stability-beta-33bbff.svg?style=for-the-badge
 [stability-info]: https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#beta
 [code-coverage-badge]: https://img.shields.io/codecov/c/gh/provenance-io/loan-package-contracts/main?label=Codecov&style=for-the-badge
@@ -25,7 +27,7 @@ smart contracts that can be executed against it.
 [proto-publication-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.loan-package/proto
 [license-badge]: https://img.shields.io/github/license/provenance-io/loan-package-contracts.svg
 [license-url]: https://github.com/provenance-io/loan-package-contracts/blob/main/LICENSE
-[loc-badge]: https://tokei.rs/b1/github/provenance-io/loan-package-contracts
+[loc-badge]: https://img.shields.io/tokei/lines/github/provenance-io/loan-package-contracts?style=for-the-badge
 [loc-url]: https://github.com/provenance-io/loan-package-contracts
 ## Development
 ### Commands

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -9,7 +9,7 @@ import tech.figure.asset.v1beta1.Asset
 import tech.figure.loan.v1beta1.LoanDocuments
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta2.LoanValidation
 
 /**
  * Denotes the string literals used in [Record] annotations for the [LoanScopeSpecification] and its contracts.
@@ -19,7 +19,13 @@ object LoanScopeFacts {
     const val documents = "documents"
     const val servicingRights = "servicingRights"
     const val servicingData = "servicingData"
+    @Deprecated(
+        message = "This label is for a record no longer supported by the latest validation contracts.",
+        replaceWith = ReplaceWith("LoanScopeFacts.loanValidationMetadata", "io.provenance.scope.loan.LoanScopeFacts"),
+        level = DeprecationLevel.WARNING,
+    )
     const val loanValidations = "loanValidations"
+    const val loanValidationMetadata = "loanValidation"
     const val eNote = "eNote"
 }
 
@@ -69,7 +75,7 @@ data class LoanPackage(
     /** Servicing data for the loan, including a list of metadata on loan states. */
     @Record(LoanScopeFacts.servicingData) var servicingData: ServicingData,
     /** A list of third-party validation iterations. */
-    @Record(LoanScopeFacts.loanValidations) var loanValidations: LoanValidation,
+    @Record(LoanScopeFacts.loanValidationMetadata) var loanValidations: LoanValidation,
     /** The eNote for the loan. */
     @Record(LoanScopeFacts.eNote) var eNote: ENote,
 )

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -32,8 +32,9 @@ import tech.figure.loan.v1beta1.LoanDocuments
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.LoanValidation
 import tech.figure.loan.v1beta1.Loan as FigureTechLoan
+import tech.figure.validation.v1beta1.LoanValidation as LoanValidation_v1beta1
+import tech.figure.validation.v1beta2.LoanValidation as LoanValidation_v1beta2
 
 @Participants(roles = [PartyType.OWNER])
 @ScopeSpecification(["tech.figure.loan"])
@@ -110,9 +111,19 @@ open class RecordLoanContract(
             )
         }
 
+    @Suppress("deprecation")
     @Function(invokedBy = PartyType.OWNER)
     @Record(LoanScopeFacts.loanValidations)
-    open fun recordValidationData(@Input(LoanScopeFacts.loanValidations) loanValidations: LoanValidation) = loanValidations.also(
+    /**
+     * Overwrites the value of the deprecated validation record.
+     *
+     * This function exists to provide backwards compatibility for scopes which used a validation record before the newer one was introduced.
+     */
+    open fun recordOldValidationData(@Input(LoanScopeFacts.loanValidations) loanValidations: LoanValidation_v1beta1) = loanValidations
+
+    @Function(invokedBy = PartyType.OWNER)
+    @Record(LoanScopeFacts.loanValidationMetadata)
+    open fun recordValidationData(@Input(LoanScopeFacts.loanValidationMetadata) loanValidations: LoanValidation_v1beta2) = loanValidations.also(
         loanValidationInputValidation
     )
 

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -10,24 +10,24 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
-import io.provenance.scope.loan.utility.loanValidationRequestValidation
 import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.validateLoanValidationRequest
 import io.provenance.scope.loan.utility.validateRequirements
-import tech.figure.validation.v1beta1.LoanValidation
-import tech.figure.validation.v1beta1.ValidationIteration
-import tech.figure.validation.v1beta1.ValidationRequest
+import tech.figure.validation.v1beta2.LoanValidation
+import tech.figure.validation.v1beta2.ValidationIteration
+import tech.figure.validation.v1beta2.ValidationRequest
 
 @Participants(roles = [PartyType.OWNER]) // TODO: Add/Change to VALIDATOR?
 @ScopeSpecification(["tech.figure.loan"])
 open class RecordLoanValidationRequestContract(
-    @Record(name = LoanScopeFacts.loanValidations, optional = true) val validationRecord: LoanValidation?,
+    @Record(name = LoanScopeFacts.loanValidationMetadata, optional = true) val validationRecord: LoanValidation?,
 ) : P8eContract() {
 
     @Function(invokedBy = PartyType.OWNER) // TODO: Add/Change to VALIDATOR?
-    @Record(LoanScopeFacts.loanValidations)
+    @Record(LoanScopeFacts.loanValidationMetadata)
     open fun recordLoanValidationRequest(@Input(LoanScopeInputs.validationRequest) submission: ValidationRequest): LoanValidation {
         validateRequirements(VALID_INPUT) {
-            loanValidationRequestValidation(submission)
+            validateLoanValidationRequest(submission)
             validationRecord?.let { existingValidationRecord ->
                 requireThat(
                     existingValidationRecord.iterationList.none { iteration ->

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -49,21 +49,37 @@ internal fun FigureTechDate?.isValidForSignedDate() = isSet() && this!!.value.is
 
 internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse { JavaUUID.fromString(value) }
 
-internal fun ContractEnforcementContext.checksumValidation(parentDescription: String = "Input", checksum: FigureTechChecksum?) {
+// TODO: Figure out how to DRY this method so it can be used with and without a ContractEnforcementContext, while still letting requireThatEach work
+internal fun ContractEnforcementContext.validateChecksum(
+    parentDescription: String = "Input",
+    checksum: FigureTechChecksum?
+): List<ContractEnforcement> =
     checksum.takeIf { it.isSet() }?.let { setChecksum ->
         requireThat(
             setChecksum.checksum.isNotBlank()  orError "$parentDescription must have a valid checksum string",
             setChecksum.algorithm.isNotBlank() orError "$parentDescription must specify a checksum algorithm",
         )
     } ?: raiseError("$parentDescription's checksum is not set")
-}
 
-internal fun ContractEnforcementContext.moneyValidation(parentDescription: String = "Input's money", money: FigureTechMoney?) {
+internal fun checksumValidation(
+    parentDescription: String = "Input",
+    checksum: FigureTechChecksum?
+): List<ContractEnforcement> =
+    checksum.takeIf { it.isSet() }?.let { setChecksum ->
+        askThat(
+            setChecksum.checksum.isNotBlank()  orError "$parentDescription must have a valid checksum string",
+            setChecksum.algorithm.isNotBlank() orError "$parentDescription must specify a checksum algorithm",
+        )
+    } ?: askToRaiseError("$parentDescription's checksum is not set")
+
+internal fun ContractEnforcementContext.moneyValidation(
+    parentDescription: String = "Input's money",
+    money: FigureTechMoney?
+): List<ContractEnforcement> =
     money.takeIf { it.isSet() }?.let { setMoney ->
         requireThat(
-            setMoney.value.matches(Regex("^[-]?([0-9]+(?:[\\\\.][0-9]+)?|\\\\.[0-9]+)\$")) orError "$parentDescription must have a valid value",
+            setMoney.value.matches(Regex("^-?([0-9]+(?:[\\\\.][0-9]+)?|\\\\.[0-9]+)\$")) orError "$parentDescription must have a valid value",
             (setMoney.currency.length == 3 && setMoney.currency.all { character -> character.isLetter() })
                 orError "$parentDescription must have a 3-letter ISO 4217 currency",
         )
     } ?: raiseError("$parentDescription is not set")
-}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestUnitTest.kt
@@ -13,7 +13,7 @@ import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationRequest
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 import io.provenance.scope.loan.utility.ContractViolationException
-import tech.figure.validation.v1beta1.ValidationRequest
+import tech.figure.validation.v1beta2.ValidationRequest
 
 class RecordLoanValidationRequestUnitTest : WordSpec({
     "recordLoanValidationRequest" When {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -18,8 +18,8 @@ import io.provenance.scope.loan.test.breakOffLast
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 import io.provenance.scope.loan.utility.ContractViolationException
 import io.provenance.scope.loan.utility.IllegalContractStateException
-import tech.figure.validation.v1beta1.LoanValidation
-import tech.figure.validation.v1beta1.ValidationResponse
+import tech.figure.validation.v1beta2.LoanValidation
+import tech.figure.validation.v1beta2.ValidationResponse
 
 class RecordLoanValidationResultsUnitTest : WordSpec({
     "recordLoanValidationResults" When {
@@ -54,7 +54,7 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
                 }
             }
         }
-        "given an input without a valid result set ID" should {
+        "given an input without a valid result ID" should {
             "throw an appropriate exception" {
                 checkAll(
                     anyValidValidationRecord,
@@ -76,13 +76,13 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
                             submission = ValidationResponse.newBuilder().also { responseBuilder ->
                                 responseBuilder.requestId = randomNewIteration.request.requestId
                                 responseBuilder.results = randomNewIteration.results.toBuilder().also { resultsBuilder ->
-                                    resultsBuilder.resultSetUuid = randomInvalidId
+                                    resultsBuilder.id = randomInvalidId
                                 }.build()
                             }.build()
                         )
                     }.let { exception ->
                         exception shouldHaveViolationCount 1
-                        exception.message shouldContain "Results must have valid result set UUID"
+                        exception.message shouldContain "Results must have valid ID"
                     }
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -8,7 +8,7 @@ import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
-import tech.figure.validation.v1beta1.LoanValidation
+import tech.figure.validation.v1beta2.LoanValidation
 import java.util.UUID as JavaUUID
 import tech.figure.util.v1beta1.UUID as FigureTechUUID
 

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
@@ -37,7 +37,7 @@ internal class TestDataGenerators : WordSpec({
                             LoanScopeFacts.eNote to randomLoanPackage.eNote,
                             LoanScopeFacts.servicingRights to randomLoanPackage.servicingRights,
                             LoanScopeFacts.servicingData to randomLoanPackage.servicingData,
-                            LoanScopeFacts.loanValidations to randomLoanPackage.loanValidations,
+                            LoanScopeFacts.loanValidationMetadata to randomLoanPackage.loanValidations,
                             LoanScopeFacts.documents to randomLoanPackage.documents,
                         )
                     )
@@ -53,7 +53,7 @@ internal class TestDataGenerators : WordSpec({
                             LoanScopeFacts.eNote to randomLoanPackage.eNote,
                             LoanScopeFacts.servicingRights to randomLoanPackage.servicingRights,
                             LoanScopeFacts.servicingData to randomLoanPackage.servicingData,
-                            LoanScopeFacts.loanValidations to randomLoanPackage.loanValidations,
+                            LoanScopeFacts.loanValidationMetadata to randomLoanPackage.loanValidations,
                             LoanScopeFacts.documents to randomLoanPackage.documents,
                         )
                     )

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
@@ -26,8 +26,8 @@ import io.provenance.scope.loan.test.PrimitiveArbs.anyNonUuidString
 import io.provenance.scope.loan.test.PrimitiveArbs.anyZoneOffset
 import io.provenance.scope.loan.test.shouldHaveViolationCount
 import io.provenance.scope.util.toProtoTimestamp
-import tech.figure.validation.v1beta1.ValidationIteration
-import tech.figure.validation.v1beta1.ValidationRequest
+import tech.figure.validation.v1beta2.ValidationIteration
+import tech.figure.validation.v1beta2.ValidationRequest
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
@@ -188,7 +188,7 @@ class DataValidationUnitTest : WordSpec({
         "throw an appropriate exception for a default instance" {
             shouldThrow<ContractViolationException> {
                 validateRequirements(ContractRequirementType.VALID_INPUT) {
-                    checksumValidation(checksum = FigureTechChecksum.getDefaultInstance())
+                    validateChecksum(checksum = FigureTechChecksum.getDefaultInstance())
                 }
             }.let { exception ->
                 exception.message shouldContain "Input's checksum is not set"
@@ -198,7 +198,7 @@ class DataValidationUnitTest : WordSpec({
             checkAll(anyNonEmptyString) { randomChecksum ->
                 shouldThrow<ContractViolationException> {
                     validateRequirements(ContractRequirementType.VALID_INPUT) {
-                        checksumValidation(
+                        validateChecksum(
                             checksum = FigureTechChecksum.newBuilder().apply {
                                 clearAlgorithm()
                                 checksum = randomChecksum
@@ -214,7 +214,7 @@ class DataValidationUnitTest : WordSpec({
             checkAll(anyNonEmptyString) { randomAlgorithm ->
                 shouldThrow<ContractViolationException> {
                     validateRequirements(ContractRequirementType.VALID_INPUT) {
-                        checksumValidation(
+                        validateChecksum(
                             checksum = FigureTechChecksum.newBuilder().apply {
                                 clearChecksum()
                                 algorithm = randomAlgorithm
@@ -229,7 +229,7 @@ class DataValidationUnitTest : WordSpec({
         "not throw an exception for any non-empty checksum and algorithm strings" {
             checkAll(anyNonEmptyString, anyNonEmptyString) { randomChecksum, randomAlgorithm ->
                 validateRequirements(ContractRequirementType.VALID_INPUT) {
-                    checksumValidation(
+                    validateChecksum(
                         checksum = FigureTechChecksum.newBuilder().apply {
                             checksum = randomChecksum
                             algorithm = randomAlgorithm

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 ## Kotlin
 kotlin = "1.8.10"
 ## Provenance
-metadataAssetModel = "0.1.14"
-p8eScopeSdk = "0.6.2"
+metadataAssetModel = "1.0.0"
+p8eScopeSdk = "0.6.4"
 ## Protocol Buffers
 grpc = "1.45.0"
 krotoPlus = "0.6.1"


### PR DESCRIPTION
## Context
Updating the contracts to be compatible with [the new major release of metadata-asset-model](https://github.com/provenance-io/metadata-asset-model/releases/tag/v1.0.0). This mainly just means adding a new `loanValidationMetadata` record in the loan scope to replace `loanValidation` — it uses a new `ValidationResultsMetadata` protobuf for storing results compared to the previous `ValidationResults`.
## Changes
### Major
- Add a deprecation warning to the string constant for the old `LoanValidation` record
- Update `RecordLoanContract` to support a requirement-free overwrite of the old `loanValidation` record, for backwards compatibility
- Update `RecordLoanContract` to support a validated overwrite of the new `loanValidationMetadata` record
- Update the validation request and results contracts to use the new protobufs and update the new record instead
### Minor
- Update provided loan wrapper class to point to the new `LoanValidation` record
- Update the string constants object `LoanScopeFacts` with a warning-level deprecation on the `loanValidation` constant
### Patch
- Add a test for & fix bugs in the code for the `requireThatEach` method
- Clean up some minor details in utility code
- Further polish the README badges
- Bump `p8e-scope-sdk` patch version