### PR TITLE
Fix publish workflow not publishing to Maven when expected

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,17 @@ on:
         description: 'The version to publish'
         required: true
         type: string
-      skipMavenPublishing:
-        description: 'Skip publishing to Maven'
+      publishToMaven:
+        description: 'Publish the contracts and proto JARs to Maven'
         type: boolean
         required: true
-        default: false
-      publishing_environment:
+        default: true
+      bootstrapContracts:
+        description: 'Bootstrap contracts to an object store'
+        type: boolean
+        required: true
+        default: true
+      publishingEnvironment:
         description: 'Environment to bootstrap the contracts to'
         required: true
         default: 'testnet'
@@ -20,45 +25,33 @@ on:
         options:
           - 'testnet'
           - 'mainnet'
-      os_url:
+      objectStoreUrl:
         description: 'Object Store URL'
-        default: 'grpcs://test.figure.com/objectstore.'
-        required: true
-        type: string
-      prov_url:
-        description: 'Provenance URL'
-        default: 'grpcs://34.148.39.82:9090'
-        required: true
-        type: string
-      chain_id:
-        description: 'Chain ID'
-        default: 'pio-testnet-1'
+        default: 'grpcs://grpc.test.figure.com/objectstore.'
         required: true
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.chain_id }}
+  group: ${{ github.workflow }}-${{ (github.event.inputs.publishToMaven || github.event.inputs.bootstrapContracts) && github.event.inputs.version || github.event.inputs.chain_id }}
   cancel-in-progress: true
 
 jobs:
   build-and-publish:
     name: Build and Publish Jar
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.publishing_environment }}
+    environment: ${{ github.event.inputs.publishingEnvironment }}
     env:
-      IS_TEST: ${{ github.event.inputs.publishing_environment == 'testnet' }}
-      OS_GRPC_URL: ${{ github.event.inputs.os_url }}
-      PROVENANCE_GRPC_URL: ${{ github.event.inputs.prov_url }}
+      IS_TEST: ${{ github.event.inputs.publishingEnvironment == 'testnet' }}
+      OS_GRPC_URL: ${{ github.event.inputs.objectStoreUrl }}
+      PROVENANCE_GRPC_URL: ${{ github.event.inputs.publishingEnvironment == 'testnet' && 'grpcs://34.148.39.82:9090' || 'grpcs://34.148.50.57:9090' }}
       ENCRYPTION_PRIVATE_KEY: ${{ secrets.ENCRYPTION_PRIVATE_KEY }}
       SIGNING_PRIVATE_KEY: ${{ secrets.SIGNING_PRIVATE_KEY }}
-      CHAIN_ID: ${{ github.event.inputs.chain_id }}
+      CHAIN_ID: ${{ github.event.inputs.publishingEnvironment == 'mainnet' && 'pio-mainnet-1' || 'pio-testnet-1' }}
       OS_GRPC_APIKEY: ${{ secrets.OS_GRPC_APIKEY }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.inputs.version }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -74,7 +67,8 @@ jobs:
       - name: Check Contract Syntax
         run: ./gradlew p8eClean p8eCheck --info --stacktrace
 
-      - name: Bootstrap Test
+      - name: Bootstrap Contracts
+        if: inputs.bootstrapContracts
         run: ./gradlew p8eBootstrap --info
 
       - name: Install gpg secret key
@@ -85,7 +79,7 @@ jobs:
           echo -n "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | base64 --decode > $GITHUB_WORKSPACE/release.gpg
 
       - name: Publish to Maven Central
-        if: github.event.inputs.skipMavenPublishing == false
+        if: inputs.publishToMaven
         run: |
           VERSION=$( echo ${{ github.event.inputs.version }} | sed -e 's/^v//' )
           ./gradlew publishToSonatype -Pversion="$VERSION" \


### PR DESCRIPTION
## Context
[The most recent publish workflow dispatch](https://github.com/provenance-io/loan-package-contracts/actions/runs/4306944476/jobs/7511405183) skipped the "Publish to Maven Central" step when it should not have. Polishing the workflow while I'm at it.
This updated workflow was successfully ran three times: [here](https://github.com/provenance-io/loan-package-contracts/actions/runs/4307420389), [here](https://github.com/provenance-io/loan-package-contracts/actions/runs/4307973177), and [here](https://github.com/provenance-io/loan-package-contracts/actions/runs/4308057714).
## Changes
- Change step conditional for "Publish to Maven Central" step to use `inputs` instead of `github.event.inputs` since the former is a boolean and the latter is a string
- Remove chain ID and Provenance GRPC URL from workflow inputs for ease of usage
- Let workflow checkout code from workflow dispatch branch rather than input, to facilitate creating semver-compliant prerelease names
- Try improving concurrency restriction
  - Whether publishing to Maven and/or bootstrapping the contracts to an object store, we don't want the same version to attempt to be published to concurrently
- Remove "test" environment reference from bootstrap step name
- Convert workflow input variable names to camel case