### PR TITLE
Define new funding contract, tweak test settings for performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,3 +19,5 @@ disabled_rules=wrapping,no-multi-spaces
 disabled_rules=no-multi-spaces
 [contract/**/utility/DataValidationExtensions.kt]
 disabled_rules=no-multi-spaces
+[contract/**/utility/FundingDataValidation.kt]
+disabled_rules=no-multi-spaces

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -27,4 +27,5 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    maxParallelForks = 2
 }

--- a/contract/build.gradle.kts
+++ b/contract/build.gradle.kts
@@ -28,4 +28,5 @@ dependencies {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     maxParallelForks = 2
+    maxHeapSize = "4096M"
 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -60,6 +60,7 @@ object LoanScopeInputs {
     const val eNoteUpdate = "newENote"
     const val eNoteControllerUpdate = "newController"
     const val newLoanStates = "newLoanStates"
+    const val funding = "newFunding"
 }
 
 /**

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContract.kt
@@ -14,7 +14,6 @@ import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.documentModificationValidation
 import io.provenance.scope.loan.utility.documentValidation
 import io.provenance.scope.loan.utility.isSet
-import io.provenance.scope.loan.utility.raiseError
 import io.provenance.scope.loan.utility.toChecksumMap
 import io.provenance.scope.loan.utility.tryUnpackingAs
 import io.provenance.scope.loan.utility.updateServicingData

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanContract.kt
@@ -15,12 +15,12 @@ import io.provenance.scope.loan.LoanScopeProperties.assetMismoKey
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
 import io.provenance.scope.loan.utility.documentValidation
 import io.provenance.scope.loan.utility.eNoteInputValidation
+import io.provenance.scope.loan.utility.fundingValidation
 import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.isValid
 import io.provenance.scope.loan.utility.loanDocumentInputValidation
 import io.provenance.scope.loan.utility.loanValidationInputValidation
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.raiseError
 import io.provenance.scope.loan.utility.servicingRightsInputValidation
 import io.provenance.scope.loan.utility.toFigureTechLoan
 import io.provenance.scope.loan.utility.tryUnpackingAs
@@ -77,6 +77,9 @@ open class RecordLoanContract(
                                 newLoan.originatorName.isNotBlank() orError "Loan is missing originator name",
                             )
                             uliValidation(newLoan.uli)
+                            newLoan.funding.takeIf { it.isSet() }?.let { newLoanFunding ->
+                                fundingValidation(newLoanFunding)
+                            }
                         }
                     }
                 }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationRequestContract.kt
@@ -10,8 +10,8 @@ import io.provenance.scope.contract.spec.P8eContract
 import io.provenance.scope.loan.LoanScopeFacts
 import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType.VALID_INPUT
+import io.provenance.scope.loan.utility.loanValidationRequestValidation
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.validateLoanValidationRequest
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.validation.v1beta2.LoanValidation
 import tech.figure.validation.v1beta2.ValidationIteration
@@ -27,7 +27,7 @@ open class RecordLoanValidationRequestContract(
     @Record(LoanScopeFacts.loanValidationMetadata)
     open fun recordLoanValidationRequest(@Input(LoanScopeInputs.validationRequest) submission: ValidationRequest): LoanValidation {
         validateRequirements(VALID_INPUT) {
-            validateLoanValidationRequest(submission)
+            loanValidationRequestValidation(submission)
             validationRecord?.let { existingValidationRecord ->
                 requireThat(
                     existingValidationRecord.iterationList.none { iteration ->

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -12,9 +12,8 @@ import io.provenance.scope.loan.LoanScopeInputs
 import io.provenance.scope.loan.utility.ContractRequirementType
 import io.provenance.scope.loan.utility.isSet
 import io.provenance.scope.loan.utility.isValid
+import io.provenance.scope.loan.utility.loanValidationResultsValidation
 import io.provenance.scope.loan.utility.orError
-import io.provenance.scope.loan.utility.raiseError
-import io.provenance.scope.loan.utility.validateLoanValidationResults
 import io.provenance.scope.loan.utility.validateRequirements
 import tech.figure.validation.v1beta2.LoanValidation
 import tech.figure.validation.v1beta2.ValidationResponse
@@ -37,7 +36,7 @@ open class RecordLoanValidationResultsContract(
             requireThat(
                 submission.requestId.isValid() orError "Response must have valid ID",
             )
-            validateLoanValidationResults(submission.results)
+            loanValidationResultsValidation(submission.results)
             validationRecord.iterationList.singleOrNull { iteration ->
                 iteration.request.requestId == submission.requestId // For now, we won't support letting results arrive before the request
             } ?: raiseError("No single validation iteration with a matching request ID exists")

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContract.kt
@@ -1,0 +1,50 @@
+package io.provenance.scope.loan.contracts
+
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications.PartyType
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.LoanScopeProperties.assetLoanKey
+import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.falseIfError
+import io.provenance.scope.loan.utility.fundingValidation
+import io.provenance.scope.loan.utility.isSet
+import io.provenance.scope.loan.utility.orError
+import io.provenance.scope.loan.utility.toFigureTechLoan
+import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.asset.v1beta1.Asset
+import tech.figure.loan.v1beta1.Funding
+import tech.figure.proto.util.toProtoAny
+
+@Participants(roles = [PartyType.OWNER])
+@ScopeSpecification(["tech.figure.loan"])
+open class UpdateFundingContract(
+    @Record(name = LoanScopeFacts.asset, optional = false) val existingAsset: Asset,
+) : P8eContract() {
+
+    @Function(invokedBy = PartyType.OWNER)
+    @Record(LoanScopeFacts.asset)
+    open fun updateFunding(@Input(LoanScopeInputs.funding) newFunding: Funding): Asset {
+        validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
+            requireThat(
+                (falseIfError {
+                    existingAsset.kvMap[assetLoanKey]!!.toFigureTechLoan().isSet()
+                }) orError "An existing loan must be defined in the asset"
+            )
+        }
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            fundingValidation(newFunding)
+        }
+        val newLoan = existingAsset.kvMap[assetLoanKey]!!.toFigureTechLoan().toBuilder().also { existingLoanBuilder ->
+            existingLoanBuilder.funding = newFunding
+        }.build()
+        return existingAsset.toBuilder().also { existingAssetBuilder ->
+            existingAssetBuilder.putKv(assetLoanKey, newLoan.toProtoAny())
+        }.build()
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/DataValidationExtensions.kt
@@ -6,6 +6,7 @@ import com.google.protobuf.Message as ProtobufMessage
 import com.google.protobuf.Timestamp as ProtobufTimestamp
 import java.time.LocalDate as JavaLocalDate
 import java.util.UUID as JavaUUID
+import tech.figure.util.v1beta1.Address as FigureTechAddress
 import tech.figure.util.v1beta1.Checksum as FigureTechChecksum
 import tech.figure.util.v1beta1.Date as FigureTechDate
 import tech.figure.util.v1beta1.Money as FigureTechMoney
@@ -36,10 +37,7 @@ internal fun ProtobufTimestamp?.isValid() = this !== null
 
 internal fun ProtobufTimestamp?.isValidAndNotInFuture() = this !== null && toInstant() <= Instant.now()
 
-internal fun ProtobufTimestamp?.isValidForFundingTime() =
-    this !== null &&
-        this != defaultInstanceForType &&
-        toInstant() <= Instant.now()
+internal fun ProtobufTimestamp?.isValidFundingTime() = this !== null && this != defaultInstanceForType && toInstant() <= Instant.now()
 
 internal fun ProtobufTimestamp?.isValidForLoanState() =
     this !== null &&
@@ -53,6 +51,12 @@ internal fun FigureTechDate?.isValidForSignedDate() = isSet() && this!!.value.is
 }
 
 internal fun FigureTechUUID?.isValid() = isSet() && this!!.value.isNotBlank() && tryOrFalse { JavaUUID.fromString(value) }
+
+internal fun FigureTechAddress?.isValid() = this !== null && street.isNotBlank() && city.isNotBlank() && state.isNotBlank() && zip.isNotBlank()
+
+private val validProvenanceAddress = Regex("^(pb|tp)1.{38}.*")
+
+internal fun String?.isValidProvenanceAddress() = this !== null && matches(validProvenanceAddress)
 
 internal fun EnforcementContext.checksumValidation(
     parentDescription: String = "Input",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
@@ -1,0 +1,106 @@
+package io.provenance.scope.loan.utility
+
+import tech.figure.loan.v1beta1.Funding
+import tech.figure.util.v1beta1.ACH
+
+internal fun Funding?.isSet() = this !== null && (status.isSet() || started.isSet() || completed.isSet() || disbursementsCount > 0)
+
+internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = { funding ->
+    if (funding.isSet()) {
+        funding.status.takeIf { it.isSet() }?.also { fundingStatus ->
+            requireThat(
+                fundingStatus.status.isNotBlank()                   orError "Funding status must not be blank",
+                fundingStatus.effectiveTime.isValidForFundingTime() orError "Funding status must have valid effective time",
+            )
+        } ?: raiseError("Funding status must be set")
+        requireThat(
+            funding.started.isValidForFundingTime()   orError "Funding start time must be valid",
+            funding.completed.isValidForFundingTime() orError "Funding end time must be valid",
+        )
+        if (funding.disbursementsCount > 0) {
+            val incomingDisbursementIds = mutableMapOf<String, UInt>()
+            funding.disbursementsList.requireThatEach { disbursement ->
+                disbursement.takeIf { it.isSet() }?.also { setDisbursement ->
+                    setDisbursement.id.takeIf { it.isSet() }?.value?.also { disbursementId ->
+                        incomingDisbursementIds[disbursementId] = incomingDisbursementIds.getOrDefault(disbursementId, 0U) + 1U
+                    }
+                    requireThat(
+                        setDisbursement.id.isValid()                      orError "Disbursement must have valid ID",
+                        setDisbursement.started.isValidForFundingTime()   orError "Disbursement start time must be valid",
+                        setDisbursement.completed.isValidForFundingTime() orError "Disbursement end time must be valid",
+                        (setDisbursement.amount.value.toDoubleOrNull()?.let { it >= 0 } ?: true)
+                            orError "Disbursement amount must not be negative",
+                    )
+                    setDisbursement.status.takeIf { it.isSet() }?.also { disbursementStatus ->
+                        requireThat(
+                            (disbursementStatus.status in listOf("UNFUNDED", "INITIATED", "COMPLETED", "CANCELLED")) // TODO: Confirm if desired
+                                orError "Disbursement status must be valid",
+                            disbursementStatus.effectiveTime.isValidForFundingTime() orError "Disbursement must have valid effective time",
+                        )
+                    } ?: raiseError("Disbursement status must be set")
+                    moneyValidation("Disbursement amount", setDisbursement.amount)
+                    setDisbursement.disburseAccount.takeIf { it.isSet() }?.also { disburseAccount ->
+                        requireThat(
+                            disburseAccount.accountOwnerId.isValid() orError "Disbursement account must have valid owner ID",
+                            (disburseAccount.financial.isSet() xor disburseAccount.provenance.isSet())
+                                orError "Disbursement account must have exactly one specific type",
+                        )
+                        disburseAccount.financial.takeIf { it.isSet() }?.also { financialAccount ->
+                            requireThat(
+                                financialAccount.id.isSet()
+                                    orError "Disbursement bank account ID must be set",
+                                (financialAccount.accountNumber.length in 4..17)
+                                    orError "Disbursement bank account must have a valid account number",
+                                (financialAccount.routingNumber.length == 9)
+                                    orError "Disbursement bank account must have a valid routing number",
+                            )
+                            financialAccount.movementList.requireThatEach(listIndices = false) { moneyMovement ->
+                                requireThat(
+                                    (moneyMovement.ach.isSet() xor moneyMovement.wire.isSet()) orError
+                                        "Disbursement bank account money movement must have exactly one specific type",
+                                    (
+                                        moneyMovement.ach.isNotSet() ||
+                                            moneyMovement.ach.accountType !in listOf(
+                                            ACH.AccountType.ACCOUNT_TYPE_UNKNOWN,
+                                            ACH.AccountType.UNRECOGNIZED,
+                                        )
+                                        ) orError
+                                        "Disbursement bank account for ACH must have a valid type",
+                                    (moneyMovement.wire.isNotSet() || moneyMovement.wire.accountAddress.isSet())
+                                        orError "Disbursement bank account for wires must have a valid address",
+                                    (moneyMovement.wire.isNotSet() || moneyMovement.wire.wireInstructions.isNotBlank())
+                                        orError "Disbursement bank account for wires must have valid wire instructions",
+                                    (
+                                        moneyMovement.wire.isNotSet() ||
+                                            moneyMovement.wire.swiftInstructions.isNotSet() ||
+                                            moneyMovement.wire.swiftInstructions.swiftId.isNotBlank()
+                                        ) orError "Disbursement bank account for wires must have valid SWIFT bank account ID",
+                                    (
+                                        moneyMovement.wire.isNotSet() ||
+                                            moneyMovement.wire.swiftInstructions.isNotSet() ||
+                                            moneyMovement.wire.swiftInstructions.swiftBankAddress.isSet()
+                                        ) orError "Disbursement bank account for wires must have valid SWIFT bank mailing address",
+                                )
+                            }
+                        }
+                        disburseAccount.provenance.takeIf { it.isSet() }?.also { provenanceAccount ->
+                            requireThat(
+                                provenanceAccount.address.matches(Regex("^(pb|tp)1.{38}.*"))
+                                    orError "Disbursement account's Provenance address must be valid",
+                            )
+                        }
+                    } ?: raiseError("Disbursement account is not set")
+                } ?: raiseError("Disbursement is not set")
+            }
+            incomingDisbursementIds.entries.forEach { (iterationId, count) ->
+                if (count > 1U) {
+                    raiseError("Disbursement ID $iterationId is not unique ($count usages)")
+                }
+            }
+        } else {
+            raiseError("Must supply at least one disbursement entry")
+        }
+    } else {
+        raiseError("Funding is not set")
+    }
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/AppendLoanDocumentsContractUnitTest.kt
@@ -38,7 +38,7 @@ import kotlin.math.max
 
 class AppendLoanDocumentsContractUnitTest : WordSpec({
     "appendDocuments" When {
-        val maxDocumentCount = (if (KotestConfig.runTestsExtended) 20 else 5)
+        val maxDocumentCount = (if (KotestConfig.runTestsExtended) 15 else 5)
         "given an empty input" should {
             "throw an appropriate exception" {
                 checkAll(

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordENoteContractUnitTest.kt
@@ -245,10 +245,10 @@ class RecordENoteContractUnitTest : WordSpec({
                         anyAssetType,
                         anyBorrowerInfo(additionalBorrowerCount = 0..1),
                         anyNonNegativeMoney,
-                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 100 else 10).flatMap { randomLoanDocumentCount ->
+                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 30 else 10).flatMap { randomLoanDocumentCount ->
                             anyValidDocumentSet(size = randomLoanDocumentCount, slippage = 70)
                         },
-                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 100 else 10).flatMap { randomLoanStateCount ->
+                        Arb.int(min = 1, max = if (KotestConfig.runTestsExtended) 30 else 10).flatMap { randomLoanStateCount ->
                             loanStateSet(size = randomLoanStateCount, slippage = 70)
                         },
                     ) { randomLoanId, randomAssetType, randomBorrowerInfo, randomOriginalNoteAmount, randomServicingDocuments, randomLoanStates ->

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanContractUnitTest.kt
@@ -431,7 +431,7 @@ class RecordLoanContractUnitTest : WordSpec({
         "given an asset which removes the MISMO loan from an existing loan record" should {
             "not throw an exception" {
                 checkAll(
-                    anyValidAsset(hasMismoLoan = true),
+                    anyValidAsset(hasMismoLoan = true, hasFunding = true),
                 ) { randomExistingAsset ->
                     val randomNewAsset = randomExistingAsset.toBuilder().also { newAssetBuilder ->
                         newAssetBuilder.removeKv(assetMismoKey)
@@ -455,7 +455,7 @@ class RecordLoanContractUnitTest : WordSpec({
         "given an asset which adds a MISMO loan to an existing loan record" should {
             "not throw an exception" {
                 checkAll(
-                    anyValidAsset(hasMismoLoan = true),
+                    anyValidAsset(hasMismoLoan = true, hasFunding = true),
                 ) { randomNewAsset ->
                     val randomExistingAsset = randomNewAsset.toBuilder().also { existingAssetBuilder ->
                         existingAssetBuilder.removeKv(assetMismoKey)
@@ -508,7 +508,7 @@ class RecordLoanContractUnitTest : WordSpec({
         "given an input with a MISMO loan but no Figure Tech loan to update an existing Figure Tech loan record" should {
             "throw an appropriate exception" {
                 checkAll(
-                    anyValidAsset(hasMismoLoan = true),
+                    anyValidAsset(hasMismoLoan = true, hasFunding = true),
                 ) { randomBaseAsset ->
                     val randomExistingAsset = randomBaseAsset.toBuilder().also { existingAssetBuilder ->
                         existingAssetBuilder.removeKv(assetMismoKey)

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsUnitTest.kt
@@ -36,7 +36,7 @@ class RecordLoanValidationResultsUnitTest : WordSpec({
                 }
             }
         }
-        val anyValidValidationRecord = Arb.int(min = 1, max = (if (KotestConfig.runTestsExtended) 20 else 5)).flatMap { iterationCount ->
+        val anyValidValidationRecord = Arb.int(min = 1, max = (if (KotestConfig.runTestsExtended) 15 else 5)).flatMap { iterationCount ->
             anyValidValidationRecord(iterationCount = iterationCount)
         }
         "given an empty input" should {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContractUnitTest.kt
@@ -1,0 +1,935 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.ExperimentalKotest
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.filterNot
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.of
+import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.set
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyFutureTimestamp
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidAch
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidAsset
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidFinancialAccount
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidFunding
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidProvenanceAccount
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidWire
+import io.provenance.scope.loan.test.PrimitiveArbs.anyBlankString
+import io.provenance.scope.loan.test.PrimitiveArbs.anyNonUuidString
+import io.provenance.scope.loan.test.shouldContainAtLeastOneOf
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.loan.v1beta1.Funding
+import tech.figure.util.v1beta1.UUID
+import tech.figure.util.v1beta1.ACH.AccountType as ACHAccountType
+
+class UpdateFundingContractUnitTest : WordSpec({
+    /* Helpers */
+    fun <T> fundingWithDataSet(disbursementCount: IntRange, dataArb: (Int) -> Arb<List<T>>): Arb<Pair<Funding, Pair<Set<Int>, List<T>>>> =
+        anyValidFunding(disbursementCount = disbursementCount).flatMap { funding ->
+            Arb.pair(
+                Arb.of(funding),
+                funding.disbursementsCount.let { disbursementCount ->
+                    Arb.int(min = 2, max = disbursementCount).flatMap { dataCount ->
+                        Arb.pair(
+                            Arb.set(gen = Arb.int(min = 0, max = disbursementCount - 1), size = dataCount, slippage = 15),
+                            dataArb(dataCount)
+                        )
+                    }
+                },
+            )
+        }
+    /* Tests */
+    "updateFunding" When {
+        "given an empty input" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidAsset) { randomExistingAsset ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            Funding.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding is not set"
+                    }
+                }
+            }
+        }
+        "given an input without a funding status" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().clearStatus().build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding status must be set"
+                    }
+                }
+            }
+        }
+        "given an input without a funding status value" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.status = fundingBuilder.statusBuilder.also { statusBuilder ->
+                                    statusBuilder.clearStatus()
+                                }.build()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding status must not be blank"
+                    }
+                }
+            }
+        }
+        "given an input without a funding status effective time" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.status = fundingBuilder.statusBuilder.also { statusBuilder ->
+                                    statusBuilder.clearEffectiveTime()
+                                }.build()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding status must have valid effective time"
+                    }
+                }
+            }
+        }
+        "given an input with a funding status effective time in the future" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                    anyFutureTimestamp,
+                ) { randomExistingAsset, randomNewFunding, randomFutureTimestamp ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.status = fundingBuilder.statusBuilder.also { statusBuilder ->
+                                    statusBuilder.effectiveTime = randomFutureTimestamp
+                                }.build()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding status must have valid effective time"
+                    }
+                }
+            }
+        }
+        "given an input without a funding start time" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().clearStarted().build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding start time must be valid"
+                    }
+                }
+            }
+        }
+        "given an input with a funding start time in the future" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                    anyFutureTimestamp,
+                ) { randomExistingAsset, randomNewFunding, randomFutureTimestamp ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.started = randomFutureTimestamp
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding start time must be valid"
+                    }
+                }
+            }
+        }
+        "given an input without a funding end time" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().clearCompleted().build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding end time must be valid"
+                    }
+                }
+            }
+        }
+        "given an input with a funding end time in the future" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..6),
+                    anyFutureTimestamp,
+                ) { randomExistingAsset, randomNewFunding, randomFutureTimestamp ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.completed = randomFutureTimestamp
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Funding end time must be valid"
+                    }
+                }
+            }
+        }
+        "given an input without disbursements" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 0..0),
+                ) { randomExistingAsset, randomNewFunding ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Must supply at least one disbursement entry"
+                    }
+                }
+            }
+        }
+        "given an input with duplicate disbursement IDs" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 2..6).flatMap { funding ->
+                        Arb.pair(
+                            Arb.of(funding),
+                            funding.disbursementsCount.let { disbursementCount ->
+                                Arb.int(min = 2, max = disbursementCount).flatMap { duplicateIdCount ->
+                                    Arb.set(gen = Arb.int(min = 0, max = disbursementCount - 1), size = duplicateIdCount, slippage = 15)
+                                }
+                            },
+                        )
+                    },
+                    anyUuid,
+                ) { randomExistingAsset, (randomNewFunding, duplicateIdIndices), randomId ->
+                    randomNewFunding.toBuilder().also { fundingBuilder ->
+                        duplicateIdIndices.forEach { index ->
+                            fundingBuilder.setDisbursements(
+                                index,
+                                fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                    disbursementBuilder.id = randomId
+                                }.build()
+                            )
+                        }
+                    }.build().let { newFunding ->
+                        shouldThrow<ContractViolationException> {
+                            UpdateFundingContract(
+                                existingAsset = randomExistingAsset,
+                            ).updateFunding(
+                                newFunding
+                            )
+                        }.let { exception ->
+                            exception shouldHaveViolationCount 1
+                            newFunding.disbursementsList.count { disbursement ->
+                                disbursement.id.value == randomId.value
+                            } shouldBeGreaterThanOrEqual duplicateIdIndices.size
+                            exception.message shouldContain Regex("Disbursement ID ${randomId.value} is not unique \\(\\d+ usages\\)")
+                        }
+                    }
+                }
+            }
+        }
+        "given an input with one or more invalid disbursement IDs" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    fundingWithDataSet(disbursementCount = 2..5) { invalidIdCount ->
+                        Arb.set(anyNonUuidString, size = invalidIdCount).map { it.toList() }
+                    },
+                ) { randomExistingAsset, (randomNewFunding, invalidIdData) ->
+                    val invalidIdIndices = invalidIdData.first
+                    val invalidIds = invalidIdData.second.toMutableList()
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                invalidIdIndices.forEach { index ->
+                                    fundingBuilder.setDisbursements(
+                                        index,
+                                        fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                            disbursementBuilder.id = UUID.newBuilder().also { idBuilder ->
+                                                idBuilder.value = invalidIds.removeAt(0)
+                                            }.build()
+                                        }.build()
+                                    )
+                                }
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain
+                            "Disbursement must have valid ID [Iteration${if (invalidIdIndices.size == 1) "" else "s"} " +
+                            "${invalidIdIndices.sorted().joinToString()}]"
+                    }
+                }
+            }
+        }
+        "given an input with one or more invalid disbursement start times" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    fundingWithDataSet(disbursementCount = 2..5) { invalidStartTimeCount ->
+                        Arb.list(anyFutureTimestamp, range = invalidStartTimeCount..invalidStartTimeCount)
+                    },
+                ) { randomExistingAsset, (randomNewFunding, invalidStartTimeData) ->
+                    val invalidStartTimeIndices = invalidStartTimeData.first
+                    val invalidStartTimes = invalidStartTimeData.second.toMutableList()
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                invalidStartTimeIndices.forEach { index ->
+                                    fundingBuilder.setDisbursements(
+                                        index,
+                                        fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                            disbursementBuilder.started = invalidStartTimes.removeAt(0)
+                                        }.build()
+                                    )
+                                }
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain
+                            "Disbursement start time must be valid [Iteration${if (invalidStartTimeIndices.size == 1) "" else "s"} " +
+                            "${invalidStartTimeIndices.sorted().joinToString()}]"
+                    }
+                }
+            }
+        }
+        "given an input with one or more invalid disbursement end times" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    fundingWithDataSet(disbursementCount = 2..5) { invalidEndTimeCount ->
+                        Arb.list(anyFutureTimestamp, range = invalidEndTimeCount..invalidEndTimeCount)
+                    },
+                ) { randomExistingAsset, (randomNewFunding, invalidEndTimeData) ->
+                    val invalidEndTimeIndices = invalidEndTimeData.first
+                    val invalidEndTimes = invalidEndTimeData.second.toMutableList()
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                invalidEndTimeIndices.forEach { index ->
+                                    fundingBuilder.setDisbursements(
+                                        index,
+                                        fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                            disbursementBuilder.completed = invalidEndTimes.removeAt(0)
+                                        }.build()
+                                    )
+                                }
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain
+                            "Disbursement end time must be valid [Iteration${if (invalidEndTimeIndices.size == 1) "" else "s"} " +
+                            "${invalidEndTimeIndices.sorted().joinToString()}]"
+                    }
+                }
+            }
+        }
+        "given an input with one or more invalid disbursement amounts" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    fundingWithDataSet(disbursementCount = 2..5) { invalidAmountCount ->
+                        Arb.list(
+                            Arb.string().filterNot { it.matches(Regex("^([0-9]+(?:[.][0-9]+)?|\\.[0-9]+)$")) },
+                            range = invalidAmountCount..invalidAmountCount,
+                        )
+                    },
+                ) { randomExistingAsset, (randomNewFunding, invalidAmountData) ->
+                    val invalidAmountIndices = invalidAmountData.first
+                    val invalidAmounts = invalidAmountData.second.toMutableList()
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                invalidAmountIndices.forEach { index ->
+                                    fundingBuilder.setDisbursements(
+                                        index,
+                                        fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                            disbursementBuilder.amount = disbursementBuilder.amountBuilder.also { amountBuilder ->
+                                                amountBuilder.value = invalidAmounts.removeAt(0)
+                                            }.build()
+                                        }.build()
+                                    )
+                                }
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContainAtLeastOneOf listOf(
+                            "Disbursement amount must not be negative [Iteration${if (invalidAmountIndices.size == 1) "" else "s"} " +
+                                "${invalidAmountIndices.sorted().joinToString()}]",
+                            "Disbursement amount must have a valid value [Iteration${if (invalidAmountIndices.size == 1) "" else "s"} " +
+                                "${invalidAmountIndices.sorted().joinToString()}]",
+                        )
+                    }
+                }
+            }
+        }
+        "given an input with disbursements which have no account" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..5).flatMap { funding ->
+                        Arb.pair(
+                            Arb.of(funding),
+                            funding.disbursementsCount.let { disbursementCount ->
+                                Arb.int(min = 1, max = disbursementCount).flatMap { missingAccountCount ->
+                                    Arb.set(gen = Arb.int(min = 0, max = disbursementCount - 1), size = missingAccountCount, slippage = 15)
+                                }
+                            },
+                        )
+                    },
+                ) { randomExistingAsset, (randomNewFunding, missingAccountIndices) ->
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                missingAccountIndices.forEach { index ->
+                                    fundingBuilder.setDisbursements(
+                                        index,
+                                        fundingBuilder.getDisbursementsBuilder(index).also { disbursementBuilder ->
+                                            disbursementBuilder.clearDisburseAccount()
+                                        }.build()
+                                    )
+                                }
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement account is not set " +
+                            "[Iteration${if (missingAccountIndices.size == 1) "" else "s"} ${missingAccountIndices.sorted().joinToString()}]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without an account ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyInvalidUuid,
+                ) { randomExistingAsset, randomNewFunding, randomInvalidId ->
+                    val invalidAccountIdIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIdIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIdIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.accountOwnerId = randomInvalidId
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement account must have valid owner ID [Iteration $invalidAccountIdIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without a bank account ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount ->
+                    val invalidAccountIdIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIdIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIdIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                bankAccountBuilder.clearId()
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account ID must be set [Iteration $invalidAccountIdIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without a valid bank account number" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    Arb.string().filterNot { it.length in 4..17 },
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomInvalidAccountNumber ->
+                    val invalidAccountNumberIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountNumberIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountNumberIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                bankAccountBuilder.accountNumber = randomInvalidAccountNumber
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account must have a valid account number " +
+                            "[Iteration $invalidAccountNumberIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without a valid bank routing number" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    Arb.string().filterNot { it.length == 9 },
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomInvalidRoutingNumber ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                bankAccountBuilder.routingNumber = randomInvalidRoutingNumber
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account must have a valid routing number " +
+                            "[Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without a valid bank routing number" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    Arb.string().filterNot { it.length == 9 },
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomInvalidRoutingNumber ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                bankAccountBuilder.routingNumber = randomInvalidRoutingNumber
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account must have a valid routing number " +
+                            "[Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement which has a money movement with an invalid ACH account type" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    anyValidAch,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomAch ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                val invalidMovementIndex = randomBankAccount.movementCount - 1
+                                                bankAccountBuilder.setMovement(
+                                                    invalidMovementIndex,
+                                                    bankAccountBuilder.getMovementBuilder(invalidMovementIndex).also { movementBuilder ->
+                                                        movementBuilder.clearWire()
+                                                        movementBuilder.ach = randomAch.toBuilder().also { achBuilder ->
+                                                            achBuilder.accountType = ACHAccountType.ACCOUNT_TYPE_UNKNOWN
+                                                        }.build()
+                                                    }.build()
+                                                )
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain Regex("Disbursement .* \\[1 instance] \\[Iteration $invalidAccountIndex]")
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement which has a money movement without a wire account address" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    anyValidWire,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomWire ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                val invalidMovementIndex = randomBankAccount.movementCount - 1
+                                                bankAccountBuilder.setMovement(
+                                                    invalidMovementIndex,
+                                                    bankAccountBuilder.getMovementBuilder(invalidMovementIndex).also { movementBuilder ->
+                                                        movementBuilder.clearAch()
+                                                        movementBuilder.wire = randomWire.toBuilder().also { achBuilder ->
+                                                            achBuilder.clearAccountAddress()
+                                                        }.build()
+                                                    }.build()
+                                                )
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account for wires must have a valid address " +
+                            "[1 instance] [Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement which has a money movement without wire instructions" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    anyValidWire,
+                    anyBlankString,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomWire, randomBlankString ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                val invalidMovementIndex = randomBankAccount.movementCount - 1
+                                                bankAccountBuilder.setMovement(
+                                                    invalidMovementIndex,
+                                                    bankAccountBuilder.getMovementBuilder(invalidMovementIndex).also { movementBuilder ->
+                                                        movementBuilder.clearAch()
+                                                        movementBuilder.wire = randomWire.toBuilder().also { achBuilder ->
+                                                            achBuilder.wireInstructions = randomBlankString
+                                                        }.build()
+                                                    }.build()
+                                                )
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account for wires must have valid wire instructions " +
+                            "[1 instance] [Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement which has a money movement without a SWIFT bank account ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    anyValidWire,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomWire ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                val invalidMovementIndex = randomBankAccount.movementCount - 1
+                                                bankAccountBuilder.setMovement(
+                                                    invalidMovementIndex,
+                                                    bankAccountBuilder.getMovementBuilder(invalidMovementIndex).also { movementBuilder ->
+                                                        movementBuilder.clearAch()
+                                                        movementBuilder.wire = randomWire.toBuilder().also { achBuilder ->
+                                                            achBuilder.swiftInstructions = achBuilder.swiftInstructionsBuilder.also { swiftBuilder ->
+                                                                swiftBuilder.clearSwiftId()
+                                                            }.build()
+                                                        }.build()
+                                                    }.build()
+                                                )
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account for wires must have valid SWIFT bank account ID " +
+                            "[1 instance] [Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement which has a money movement without a SWIFT bank mailing address" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidFinancialAccount,
+                    anyValidWire,
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomWire ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearProvenance()
+                                            accountBuilder.financial = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                val invalidMovementIndex = randomBankAccount.movementCount - 1
+                                                bankAccountBuilder.setMovement(
+                                                    invalidMovementIndex,
+                                                    bankAccountBuilder.getMovementBuilder(invalidMovementIndex).also { movementBuilder ->
+                                                        movementBuilder.clearAch()
+                                                        movementBuilder.wire = randomWire.toBuilder().also { achBuilder ->
+                                                            achBuilder.swiftInstructions = achBuilder.swiftInstructionsBuilder.also { swiftBuilder ->
+                                                                swiftBuilder.clearSwiftBankAddress()
+                                                            }.build()
+                                                        }.build()
+                                                    }.build()
+                                                )
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain "Disbursement bank account for wires must have valid SWIFT bank mailing address " +
+                            "[1 instance] [Iteration $invalidAccountIndex]"
+                    }
+                }
+            }
+        }
+        "given an input with a disbursement without a valid Provenance account address" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    anyValidFunding(disbursementCount = 1..7),
+                    anyValidProvenanceAccount,
+                    Arb.string(maxSize = 40),
+                ) { randomExistingAsset, randomNewFunding, randomBankAccount, randomInvalidProvenanceAddress ->
+                    val invalidAccountIndex = randomNewFunding.disbursementsCount - 1
+                    shouldThrow<ContractViolationException> {
+                        UpdateFundingContract(
+                            existingAsset = randomExistingAsset,
+                        ).updateFunding(
+                            randomNewFunding.toBuilder().also { fundingBuilder ->
+                                fundingBuilder.setDisbursements(
+                                    invalidAccountIndex,
+                                    fundingBuilder.getDisbursementsBuilder(invalidAccountIndex).also { disbursementBuilder ->
+                                        disbursementBuilder.disburseAccount = disbursementBuilder.disburseAccountBuilder.also { accountBuilder ->
+                                            accountBuilder.clearFinancial()
+                                            accountBuilder.provenance = randomBankAccount.toBuilder().also { bankAccountBuilder ->
+                                                bankAccountBuilder.address = randomInvalidProvenanceAddress
+                                            }.build()
+                                        }.build()
+                                    }.build()
+                                )
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message!! shouldContain Regex("Disbursement account.* \\[Iteration $invalidAccountIndex]")
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
+            "not throw an exception" {
+                checkAll(
+                    if (KotestConfig.runTestsExtended) anyValidAsset else anyValidAsset(hasMismoLoan = false, hasFunding = false),
+                    Arb.int(range = 1..10).flatMap { disbursementCount -> anyValidFunding(disbursementCount = 1..disbursementCount) },
+                ) { randomExistingAsset, randomNewFunding ->
+                    UpdateFundingContract(
+                        existingAsset = randomExistingAsset,
+                    ).updateFunding(
+                        newFunding = randomNewFunding,
+                    )
+                }
+            }
+        }
+    }
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+    @ExperimentalKotest
+    override fun concurrency() = 1
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestConfig.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestConfig.kt
@@ -1,12 +1,16 @@
 package io.provenance.scope.loan.test
 
+import io.kotest.common.ExperimentalKotest
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.SpecExecutionOrder
 
+@OptIn(ExperimentalKotest::class)
 object KotestConfig : AbstractProjectConfig() {
     override val specExecutionOrder = SpecExecutionOrder.Random
-    override val parallelism = 4 // An experimental value - greater values may still improve performance
-    /** Runs tests without cutting corners in edge cases or iteration counts. If true, will greatly increase time for tests to run. */
+    override val parallelism = 4
+    override val concurrentSpecs = 2
+    override val concurrentTests = 4
+    /** Option to run tests without cutting corners in edge cases or iteration counts. If true, may greatly increase test runtime. */
     val runTestsExtended: Boolean
         get() = System.getenv("RUN_KOTEST_EXTENDED") == "true"
 }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -31,6 +31,7 @@ import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.pair
 import io.kotest.property.arbitrary.set
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.stringPattern
 import io.kotest.property.arbitrary.uInt
 import io.kotest.property.arbitrary.uuid
 import io.provenance.scope.loan.LoanPackage
@@ -41,14 +42,26 @@ import io.provenance.scope.loan.utility.ContractViolationMap
 import io.provenance.scope.loan.utility.IllegalContractStateException
 import io.provenance.scope.loan.utility.UnexpectedContractStateException
 import tech.figure.asset.v1beta1.Asset
+import tech.figure.loan.v1beta1.Disbursement
+import tech.figure.loan.v1beta1.Funding
 import tech.figure.loan.v1beta1.LoanDocuments
 import tech.figure.loan.v1beta1.MISMOLoanMetadata
 import tech.figure.proto.util.toProtoAny
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.LoanStateMetadata
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
+import tech.figure.util.v1beta1.ACH
+import tech.figure.util.v1beta1.ACH.AccountType
+import tech.figure.util.v1beta1.Account
+import tech.figure.util.v1beta1.Address
 import tech.figure.util.v1beta1.AssetType
 import tech.figure.util.v1beta1.DocumentMetadata
+import tech.figure.util.v1beta1.FinancialAccount
+import tech.figure.util.v1beta1.MoneyMovement
+import tech.figure.util.v1beta1.ProvenanceAccount
+import tech.figure.util.v1beta1.SWIFT
+import tech.figure.util.v1beta1.Status
+import tech.figure.util.v1beta1.WIRE
 import tech.figure.validation.v1beta2.LoanValidation
 import tech.figure.validation.v1beta2.ValidationItem
 import tech.figure.validation.v1beta2.ValidationIteration
@@ -141,7 +154,7 @@ internal object MetadataAssetModelArbs {
             }
         }
     val anyNonNegativeMoney: Arb<FigureTechMoney> = Arb.bind(
-        Arb.double(min = 0.0).filterNot { double -> double in listOf(Double.NaN, Double.POSITIVE_INFINITY) }.toSimpleString(),
+        Arb.stringPattern(Regex("^([0-9]+(?:[.][0-9]+)?|\\.[0-9]+)$").pattern),
         Arb.string(size = 3, codepoints = Codepoint.az()),
     ) { amount, currency ->
         FigureTechMoney.newBuilder().also { moneyBuilder ->
@@ -216,9 +229,185 @@ internal object MetadataAssetModelArbs {
     }.filterNot { date ->
         date.value === JavaLocalDate.of(1970, 1, 1).toString()
     }
+    val anyValidAddress: Arb<Address> = Arb.bind(
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.string(),
+        Arb.string(),
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.string(),
+        PrimitiveArbs.anyNonEmptyString,
+        PrimitiveArbs.anyNonEmptyString,
+    ) { street, street2, street3, city, state, country, zip, unitNumber, addressType, ownershipType ->
+        Address.newBuilder().also { addressBuilder ->
+            addressBuilder.street = street
+            addressBuilder.street2 = street2
+            addressBuilder.street3 = street3
+            addressBuilder.city = city
+            addressBuilder.state = state
+            addressBuilder.country = country
+            addressBuilder.zip = zip
+            addressBuilder.unitNumber = unitNumber
+            addressBuilder.addressType = addressType
+            addressBuilder.ownershipType = ownershipType
+        }.build()
+    }
     val anyValidTimestamp: Arb<Timestamp> = anyTimestampComponents.toTimestamp()
     val anyPastNonEpochTimestamp: Arb<Timestamp> = anyPastNonEpochTimestampComponents.toTimestamp()
     val anyFutureTimestamp: Arb<Timestamp> = anyFutureTimestampComponents.toTimestamp()
+    val anyPastStatus: Arb<Status> = Arb.bind(
+        PrimitiveArbs.anyNonEmptyString,
+        anyPastNonEpochTimestamp,
+    ) { status, effectiveTime ->
+        Status.newBuilder().also { statusBuilder ->
+            statusBuilder.status = status
+            statusBuilder.effectiveTime = effectiveTime
+        }.build()
+    }
+    val anyValidAch: Arb<ACH> = Arb.bind(
+        Arb.of(AccountType.CHECKING, AccountType.SAVINGS, AccountType.OTHER),
+        Arb.string(),
+    ) { accountType, ownerType ->
+        ACH.newBuilder().also { achBuilder ->
+            achBuilder.accountType = accountType
+            achBuilder.ownerType = ownerType
+        }.build()
+    }
+    val anyValidWire: Arb<WIRE> = Arb.bind(
+        anyValidAddress,
+        PrimitiveArbs.anyNonEmptyString,
+        Arb.bind(
+            PrimitiveArbs.anyNonEmptyString,
+            anyValidAddress,
+        ) { swiftId, swiftBankAddress ->
+            SWIFT.newBuilder().also { swiftBuilder ->
+                swiftBuilder.swiftId = swiftId
+                swiftBuilder.swiftBankAddress = swiftBankAddress
+            }.build()
+        },
+    ) { accountAddress, wireInstructions, swiftInstructions ->
+        WIRE.newBuilder().also { wireBuilder ->
+            wireBuilder.accountAddress = accountAddress
+            wireBuilder.wireInstructions = wireInstructions
+            wireBuilder.swiftInstructions = swiftInstructions
+        }.build()
+    }
+    fun anyValidMoneyMovement(
+        useACH: Boolean? = null,
+    ): Arb<MoneyMovement> = Arb.bind(
+        anyValidAch,
+        anyValidWire,
+        useACH?.let { Arb.of(it) } ?: Arb.boolean(),
+    ) { ach, wire, useAch ->
+        MoneyMovement.newBuilder().also { movementBuilder ->
+            if (useAch) {
+                movementBuilder.ach = ach
+                movementBuilder.clearWire()
+            } else {
+                movementBuilder.wire = wire
+                movementBuilder.clearAch()
+            }
+        }.build()
+    }
+    val anyValidFinancialAccount: Arb<FinancialAccount> = Arb.bind(
+        anyUuid,
+        Arb.string(),
+        Arb.string(),
+        Arb.string(minSize = 4, maxSize = 17),
+        Arb.string(size = 9),
+        Arb.list(anyValidMoneyMovement(), range = 1..3),
+    ) { id, ownerName, financialInstitution, accountNumber, routingNumber, moneyMovementList ->
+        FinancialAccount.newBuilder().also { accountBuilder ->
+            accountBuilder.id = id
+            accountBuilder.ownerName = ownerName
+            accountBuilder.financialInstitution = financialInstitution
+            accountBuilder.accountNumber = accountNumber
+            accountBuilder.routingNumber = routingNumber
+            accountBuilder.clearMovement()
+            accountBuilder.addAllMovement(moneyMovementList)
+        }.build()
+    }
+    val anyValidProvenanceAccount: Arb<ProvenanceAccount> = Arb.bind(
+        Arb.stringPattern(Regex("^(pb|tp)1.{38}.*").pattern),
+        Arb.string(),
+    ) { address, description ->
+        ProvenanceAccount.newBuilder().also { accountBuilder ->
+            accountBuilder.address = address
+            accountBuilder.description = description
+        }.build()
+    }
+    fun anyValidDisbursementAccount(
+        useBankAccount: Boolean? = null,
+    ): Arb<Account> = Arb.bind(
+        anyUuid,
+        anyValidFinancialAccount,
+        anyValidProvenanceAccount,
+        useBankAccount?.let { Arb.of(it) } ?: Arb.boolean(),
+    ) { id, financialAccount, provenanceAccount, useFinancialAccount ->
+        Account.newBuilder().also { accountBuilder ->
+            accountBuilder.accountOwnerId = id
+            if (useFinancialAccount) {
+                accountBuilder.financial = financialAccount
+                accountBuilder.clearProvenance()
+            } else {
+                accountBuilder.provenance = provenanceAccount
+                accountBuilder.clearFinancial()
+            }
+        }.build()
+    }
+    val anyValidDisbursement: Arb<Disbursement> = Arb.bind(
+        anyUuid,
+        anyNonNegativeMoney,
+        anyPastNonEpochTimestamp,
+        anyPastNonEpochTimestamp, // TODO: Validate and check that completed > started
+        Arb.bind(
+            Arb.of("UNFUNDED", "INITIATED", "COMPLETED", "CANCELLED"),
+            anyPastNonEpochTimestamp,
+        ) { status, effectiveTime ->
+            Status.newBuilder().also { statusBuilder ->
+                statusBuilder.status = status
+                statusBuilder.effectiveTime = effectiveTime
+            }.build()
+        },
+        anyValidDisbursementAccount(),
+    ) { id, amount, startedTime, completedTime, status, disbursementAccount ->
+        Disbursement.newBuilder().also { disbursementBuilder ->
+            disbursementBuilder.id = id
+            disbursementBuilder.amount = amount
+            disbursementBuilder.started = startedTime
+            disbursementBuilder.completed = completedTime
+            disbursementBuilder.status = status
+            disbursementBuilder.disburseAccount = disbursementAccount
+        }.build()
+    }
+    fun anyValidDisbursementList(size: Int, slippage: Int = 10): Arb<List<Disbursement>> = Arb.bind(
+        anyUuidSet(size = size, slippage = slippage),
+        Arb.list(anyValidDisbursement, range = size..size),
+    ) { disbursementIds, disbursements ->
+        disbursements.mapIndexed { index, disbursement ->
+            disbursement.toBuilder().also { disbursementBuilder ->
+                disbursementBuilder.id = disbursementIds[index]
+            }.build()
+        }
+    }
+    fun anyValidFunding(
+        disbursementCount: IntRange,
+    ): Arb<Funding> = Arb.bind(
+        anyPastStatus,
+        anyPastNonEpochTimestamp,
+        anyPastNonEpochTimestamp,
+        Arb.int(range = disbursementCount).flatMap { count -> anyValidDisbursementList(size = count) },
+    ) { status, startedTime, completedTime, disbursementList ->
+        Funding.newBuilder().also { fundingBuilder ->
+            fundingBuilder.status = status
+            fundingBuilder.started = startedTime
+            fundingBuilder.completed = completedTime
+            fundingBuilder.clearDisbursements()
+            fundingBuilder.addAllDisbursements(disbursementList)
+        }.build()
+    }
     val anyValidENoteController: Arb<Controller> = Arb.bind(
         anyUuid,
         PrimitiveArbs.anyNonEmptyString,
@@ -228,19 +417,26 @@ internal object MetadataAssetModelArbs {
             controllerBuilder.controllerName = controllerName
         }.build()
     }
-    val anyValidFigureTechLoan: Arb<FigureTechLoan> = Arb.bind(
+    fun anyValidFigureTechLoan(
+        hasFunding: Boolean,
+    ): Arb<FigureTechLoan> = Arb.bind(
         anyUuid,
         anyUuid,
         PrimitiveArbs.anyNonEmptyString,
         PrimitiveArbs.anyValidUli,
-    ) { loanId, originatorUuid, originatorName, uli ->
+        if (hasFunding) anyValidFunding(disbursementCount = 1..6) else Arb.of(Funding.getDefaultInstance()),
+    ) { loanId, originatorUuid, originatorName, uli, funding ->
         FigureTechLoan.newBuilder().also { loanBuilder ->
             loanBuilder.id = loanId
             loanBuilder.originatorUuid = originatorUuid
             loanBuilder.originatorName = originatorName
             loanBuilder.uli = uli
+            if (hasFunding) {
+                loanBuilder.funding = funding
+            }
         }.build()
     }
+    val anyValidFigureTechLoan: Arb<FigureTechLoan> = Arb.boolean().flatMap { hasFunding -> anyValidFigureTechLoan(hasFunding = hasFunding) }
     val anyValidMismoLoan: Arb<MISMOLoanMetadata> = Arb.bind(
         PrimitiveArbs.anyValidUli,
         anyValidDocumentMetadata,
@@ -373,40 +569,28 @@ internal object MetadataAssetModelArbs {
         }.build()
     }
     /* Loan scope records */
-    fun anyValidAsset(): Arb<Asset> =
-        Arb.boolean().flatMap { hasMismoLoan ->
-            anyValidAsset(hasMismoLoan = hasMismoLoan)
-        }
     fun anyValidAsset(
         hasMismoLoan: Boolean,
+        hasFunding: Boolean,
     ): Arb<Asset> =
-        if (hasMismoLoan) {
-            Arb.bind(
-                anyUuid,
-                PrimitiveArbs.anyNonEmptyString,
-                anyValidFigureTechLoan,
-                anyValidMismoLoan,
-            ) { assetId, assetType, figureTechLoan, mismoLoan ->
-                Asset.newBuilder().also { assetBuilder ->
-                    assetBuilder.id = assetId
-                    assetBuilder.type = assetType
-                    assetBuilder.putKv(LoanScopeProperties.assetLoanKey, figureTechLoan.toProtoAny())
+        Arb.bind(
+            anyUuid,
+            PrimitiveArbs.anyNonEmptyString,
+            anyValidFigureTechLoan(hasFunding = hasFunding),
+            if (hasMismoLoan) anyValidMismoLoan else Arb.of(MISMOLoanMetadata.getDefaultInstance()),
+        ) { assetId, assetType, figureTechLoan, mismoLoan ->
+            Asset.newBuilder().also { assetBuilder ->
+                assetBuilder.id = assetId
+                assetBuilder.type = assetType
+                assetBuilder.putKv(LoanScopeProperties.assetLoanKey, figureTechLoan.toProtoAny())
+                if (hasMismoLoan) {
                     assetBuilder.putKv(LoanScopeProperties.assetMismoKey, mismoLoan.toProtoAny())
-                }.build()
-            }
-        } else {
-            Arb.bind(
-                anyUuid,
-                PrimitiveArbs.anyNonEmptyString,
-                anyValidFigureTechLoan,
-            ) { assetId, assetType, figureTechLoan ->
-                Asset.newBuilder().also { assetBuilder ->
-                    assetBuilder.id = assetId
-                    assetBuilder.type = assetType
-                    assetBuilder.putKv(LoanScopeProperties.assetLoanKey, figureTechLoan.toProtoAny())
-                }.build()
-            }
+                }
+            }.build()
         }
+    val anyValidAsset: Arb<Asset> = Arb.pair(Arb.boolean(), Arb.boolean()).flatMap { (hasMismoLoan, hasFunding) ->
+        anyValidAsset(hasMismoLoan = hasMismoLoan, hasFunding = hasFunding)
+    }
     fun anyValidENote(
         minAssumptionCount: Int = 0,
         maxAssumptionCount: Int = 10,
@@ -509,7 +693,7 @@ internal object MetadataAssetModelArbs {
         loanDocumentCount: Int = 3,
         hasMismoLoan: Boolean,
     ): Arb<LoanPackage> = Arb.bind(
-        anyValidAsset(hasMismoLoan = hasMismoLoan),
+        Arb.boolean().flatMap { hasFunding -> anyValidAsset(hasMismoLoan = hasMismoLoan, hasFunding = hasFunding) },
         anyValidENote(maxAssumptionCount = maxAssumptionCount, maxModificationCount = maxModificationCount),
         anyValidServicingRights,
         anyValidServicingData(loanStateAndDocumentCount = loanStateCount),
@@ -529,7 +713,7 @@ internal object MetadataAssetModelArbs {
 
 /** Based on [this StackOverflow answer](https://stackoverflow.com/a/25307973). */
 internal fun Arb<Double>.toSimpleString(): Arb<String> = map { double ->
-    DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH)).apply {
+    DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH)).apply {
         maximumFractionDigits = 340
     }.format(double)
 }
@@ -572,7 +756,7 @@ private fun Arb<Pair<Long, Int>>.toTimestamp(): Arb<Timestamp> = map { (seconds,
 /**
  * Defines a custom [Matcher] to check the violation count value in a [ContractViolationException].
  */
-internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolationException> { exception ->
+private fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolationException> { exception ->
     { count: UInt ->
         if (count == 1U) {
             "$count violation"
@@ -591,6 +775,18 @@ internal fun throwViolationCount(violationCount: UInt) = Matcher<ContractViolati
     }
 }
 
+private fun containAtLeastOneOf(substrings: Iterable<String>) = Matcher<String> { message ->
+    MatcherResult(
+        substrings.any { substring -> message.contains(substring) },
+        {
+            "None of the given strings [${substrings.joinToString(limit = 5)}] were a substring of $message"
+        },
+        {
+            "None of the given strings [${substrings.joinToString(limit = 5)}] should have been a substring of $message"
+        }
+    )
+}
+
 /**
  * Wraps the custom matcher [throwViolationCount] following the style outlined in the
  * [Kotest documentation](https://kotest.io/docs/assertions/custom-matchers.html#extension-variants).
@@ -606,6 +802,14 @@ internal infix fun ContractViolationException.shouldHaveViolationCount(violation
  * This should be called by the result of [`shouldThrow<ContractViolationException>`][io.kotest.assertions.throwables.shouldThrow].
  */
 internal infix fun ContractViolationException.shouldHaveViolationCount(violationCount: Int) = shouldHaveViolationCount(violationCount.toUInt())
+
+/**
+ * Wraps the custom matcher [throwViolationCount] following the style outlined in the
+ * [Kotest documentation](https://kotest.io/docs/assertions/custom-matchers.html#extension-variants).
+ */
+internal infix fun String.shouldContainAtLeastOneOf(substrings: Iterable<String>) = apply {
+    this should containAtLeastOneOf(substrings)
+}
 
 internal fun IllegalContractStateException.shouldBeParseFailureFor(classifier: String, inputDescription: String = "input") = apply {
     message shouldContain "Could not unpack the $inputDescription as class $classifier"

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/TestDataGenerators.kt
@@ -62,12 +62,12 @@ internal class TestDataGenerators : WordSpec({
         }
         "be able to generate a random asset for a Figure Tech loan" {
             println(
-                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = false).next(randomSource))
+                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = false, hasFunding = true).next(randomSource))
             )
         }
         "be able to generate a random asset for a Figure Tech loan with a MISMO loan" {
             println(
-                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = true).next(randomSource))
+                mapper.writeValueAsString(anyValidAsset(hasMismoLoan = true, hasFunding = true).next(randomSource))
             )
         }
         "be able to generate a random eNote" {

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/ContractRequirementsUnitTest.kt
@@ -10,17 +10,16 @@ import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainIgnoringCase
-import io.kotest.matchers.string.shouldMatch
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
-import io.kotest.property.arbitrary.intArray
 import io.kotest.property.arbitrary.list
 import io.kotest.property.arbitrary.map
-import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.set
 import io.kotest.property.checkAll
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidDocumentMetadata
 import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidServicingData
@@ -92,29 +91,37 @@ class ContractRequirementsUnitTest : WordSpec({
                 checkAll(
                     Arb.int(2..30).flatMap { itemCount ->
                         Arb.pair(
-                            Arb.intArray(Arb.of(itemCount), Arb.int(min = 0)),
+                            Arb.set(Arb.int(), size = itemCount, slippage = 50),
                             Arb.int(1..itemCount)
                         )
                     }.map { (items, invalidItemCount) ->
-                        Pair(
-                            items.toList(),
-                            items.take(invalidItemCount)
-                        )
+                        items.toList().let { itemsAsList ->
+                            Pair(
+                                itemsAsList,
+                                itemsAsList.take(invalidItemCount)
+                            )
+                        }
                     },
                 ) { (items, invalidItems) ->
                     shouldThrow<ContractViolationException> {
                         validateRequirements(ContractRequirementType.VALID_INPUT) {
                             items.requireThatEach { item ->
-                                askThat(
+                                requireThat(
                                     (item !in invalidItems) orError "Item is invalid"
                                 )
                             }
                         }
                     }.let { exception ->
                         exception shouldHaveViolationCount 1
-                        exception.message shouldMatch Regex(
-                            ".*Item is invalid \\[Iterations (\\d+, )*\\d+(\\, \\.\\.\\.\\(\\d+ more omitted\\))?\\].*"
-                        )
+                        if (invalidItems.size > 5) {
+                            Regex("${invalidItems.size} instances").pattern
+                        } else {
+                            Regex(
+                                "Iteration${if (invalidItems.size == 1) "" else "s"} (\\d+, )*\\d+(, \\.\\.\\.\\(\\d+ more omitted\\))?"
+                            ).pattern
+                        }.let { violationCountSnippet ->
+                            exception.message!! shouldContain Regex("Item is invalid \\[$violationCountSnippet]")
+                        }
                     }
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataConversionExtensionsUnitTest.kt
@@ -74,7 +74,7 @@ class DataConversionExtensionsUnitTest : WordSpec({
         }
         "given a packed Figure Tech loan to unpack as a MISMO loan with inherently different fields" should {
             "throw an appropriate informative exception" {
-                checkAll(anyValidFigureTechLoan) { randomLoan ->
+                checkAll(anyValidFigureTechLoan(hasFunding = false)) { randomLoan ->
                     shouldThrow<IllegalContractStateException> {
                         validateRequirements(ContractRequirementType.LEGAL_SCOPE_STATE) {
                             randomLoan.toProtoAny().tryUnpackingAs<MISMOLoanMetadata, Unit> {}
@@ -124,7 +124,7 @@ class DataConversionExtensionsUnitTest : WordSpec({
         }
         "called on a packed Figure Tech loan" should {
             "not throw an exception" {
-                checkAll(anyValidFigureTechLoan) { randomLoan ->
+                checkAll(anyValidFigureTechLoan(hasFunding = false)) { randomLoan ->
                     randomLoan.toProtoAny().toFigureTechLoan() shouldBe randomLoan
                 }
             }

--- a/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/utility/DataValidationUnitTest.kt
@@ -188,7 +188,7 @@ class DataValidationUnitTest : WordSpec({
         "throw an appropriate exception for a default instance" {
             shouldThrow<ContractViolationException> {
                 validateRequirements(ContractRequirementType.VALID_INPUT) {
-                    validateChecksum(checksum = FigureTechChecksum.getDefaultInstance())
+                    checksumValidation(checksum = FigureTechChecksum.getDefaultInstance())
                 }
             }.let { exception ->
                 exception.message shouldContain "Input's checksum is not set"
@@ -198,7 +198,7 @@ class DataValidationUnitTest : WordSpec({
             checkAll(anyNonEmptyString) { randomChecksum ->
                 shouldThrow<ContractViolationException> {
                     validateRequirements(ContractRequirementType.VALID_INPUT) {
-                        validateChecksum(
+                        checksumValidation(
                             checksum = FigureTechChecksum.newBuilder().apply {
                                 clearAlgorithm()
                                 checksum = randomChecksum
@@ -214,7 +214,7 @@ class DataValidationUnitTest : WordSpec({
             checkAll(anyNonEmptyString) { randomAlgorithm ->
                 shouldThrow<ContractViolationException> {
                     validateRequirements(ContractRequirementType.VALID_INPUT) {
-                        validateChecksum(
+                        checksumValidation(
                             checksum = FigureTechChecksum.newBuilder().apply {
                                 clearChecksum()
                                 algorithm = randomAlgorithm
@@ -229,7 +229,7 @@ class DataValidationUnitTest : WordSpec({
         "not throw an exception for any non-empty checksum and algorithm strings" {
             checkAll(anyNonEmptyString, anyNonEmptyString) { randomChecksum, randomAlgorithm ->
                 validateRequirements(ContractRequirementType.VALID_INPUT) {
-                    validateChecksum(
+                    checksumValidation(
                         checksum = FigureTechChecksum.newBuilder().apply {
                             checksum = randomChecksum
                             algorithm = randomAlgorithm


### PR DESCRIPTION
## Context
Adding a new contract to be able to update the [Funding](https://github.com/provenance-io/metadata-asset-model/blob/363be0f729a15d0d940404f25b83eaed1cbde20a/src/main/proto/tech/figure/loan/v1beta1/loan.proto#L35) field within the asset record's loan value.
## Changes
### Minor
- Add contract with Funding proto as input which overwrite's the funding field in an existing asset record's loan value
- Mirror new funding contract's input validation into `RecordLoanContract`
### Patch
- Refactor `requireThatEach` to be a bit more typesafe and DRY repetition introduced in #62
- Tweak Gradle & Kotest configuration to try reducing test runtime
## Notes
- Some of the nested fields within the Funding proto have specific validation checks which may be obscured by a vaguer validation "Funding <fieldName> is not set" message due to the nature of their fields. These shadowed checks are still defined for thoroughness.
- The refactor of `requireThatEach` was not perfect — the changes inherently have a bit of duplicated code so that it can sufficiently handle one nested call of itself, but no more than that.