### PR TITLE
Define new contract for uploading validation results & request together

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/LoanScope.kt
@@ -57,6 +57,7 @@ object LoanScopeProperties {
 object LoanScopeInputs {
     const val validationRequest = "newRequest"
     const val validationResponse = "resultSubmission"
+    const val validationIteration = "validationIteration"
     const val eNoteUpdate = "newENote"
     const val eNoteControllerUpdate = "newController"
     const val newLoanStates = "newLoanStates"

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordLoanValidationResultsContract.kt
@@ -38,7 +38,7 @@ open class RecordLoanValidationResultsContract(
             )
             loanValidationResultsValidation(submission.results)
             validationRecord.iterationList.singleOrNull { iteration ->
-                iteration.request.requestId == submission.requestId // For now, we won't support letting results arrive before the request
+                iteration.request.requestId == submission.requestId
             } ?: raiseError("No single validation iteration with a matching request ID exists")
         }
         return validationRecord.iterationList.indexOfLast { iteration -> // The enforcement above ensures exactly one match

--- a/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordStandaloneLoanValidationResultsContract.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/contracts/RecordStandaloneLoanValidationResultsContract.kt
@@ -1,0 +1,38 @@
+package io.provenance.scope.loan.contracts
+
+import io.provenance.scope.contract.annotations.Function
+import io.provenance.scope.contract.annotations.Input
+import io.provenance.scope.contract.annotations.Participants
+import io.provenance.scope.contract.annotations.Record
+import io.provenance.scope.contract.annotations.ScopeSpecification
+import io.provenance.scope.contract.proto.Specifications.PartyType
+import io.provenance.scope.contract.spec.P8eContract
+import io.provenance.scope.loan.LoanScopeFacts
+import io.provenance.scope.loan.LoanScopeInputs
+import io.provenance.scope.loan.utility.ContractRequirementType
+import io.provenance.scope.loan.utility.loanValidationRequestValidation
+import io.provenance.scope.loan.utility.loanValidationResultsValidation
+import io.provenance.scope.loan.utility.validateRequirements
+import tech.figure.validation.v1beta2.LoanValidation
+import tech.figure.validation.v1beta2.ValidationIteration
+
+@Participants(roles = [PartyType.VALIDATOR])
+@ScopeSpecification(["tech.figure.loan"])
+open class RecordStandaloneLoanValidationResultsContract(
+    @Record(name = LoanScopeFacts.loanValidationMetadata, optional = true) val validationRecord: LoanValidation?,
+) : P8eContract() {
+
+    @Function(invokedBy = PartyType.VALIDATOR)
+    @Record(LoanScopeFacts.loanValidationMetadata)
+    open fun recordStandaloneLoanValidationResults(
+        @Input(LoanScopeInputs.validationIteration) submission: ValidationIteration
+    ): LoanValidation {
+        validateRequirements(ContractRequirementType.VALID_INPUT) {
+            loanValidationRequestValidation(submission.request)
+            loanValidationResultsValidation(submission.results)
+        }
+        return (validationRecord?.toBuilder() ?: LoanValidation.newBuilder()).also { recordBuilder ->
+            recordBuilder.addIteration(submission)
+        }.build()
+    }
+}

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/LoanContractValidations.kt
@@ -181,7 +181,6 @@ internal val loanValidationRequestValidation: EnforcementContext.(ValidationRequ
         requireThat(
             setRequest.requestId.isValid()                   orError "Request must have valid ID",
             setRequest.effectiveTime.isValidAndNotInFuture() orError "Request must have valid effective time",
-            (setRequest.blockHeight >= 0L)                   orError "Request must have valid block height",
             setRequest.validatorName.isNotBlank()            orError "Request is missing validator name",
             setRequest.requesterName.isNotBlank()            orError "Request is missing requester name",
         )

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordStandaloneLoanValidationResultsUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/RecordStandaloneLoanValidationResultsUnitTest.kt
@@ -1,0 +1,127 @@
+package io.provenance.scope.loan.contracts
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.test.TestCaseOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.flatMap
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
+import io.provenance.scope.loan.test.Constructors.standaloneResultsContractWithEmptyExistingRecord
+import io.provenance.scope.loan.test.KotestConfig
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyInvalidUuid
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationIteration
+import io.provenance.scope.loan.test.MetadataAssetModelArbs.anyValidValidationRecord
+import io.provenance.scope.loan.test.breakOffLast
+import io.provenance.scope.loan.test.shouldHaveViolationCount
+import io.provenance.scope.loan.utility.ContractViolationException
+import tech.figure.validation.v1beta2.ValidationIteration
+
+class RecordStandaloneLoanValidationResultsUnitTest : WordSpec({
+    "recordStandaloneLoanValidationResults" When {
+        "executed without a validation request existing in the scope" should {
+            "not throw an exception" {
+                checkAll(anyValidValidationIteration) { randomValidationIteration ->
+                    standaloneResultsContractWithEmptyExistingRecord.recordStandaloneLoanValidationResults(
+                        submission = randomValidationIteration,
+                    ).let { resultingRecord ->
+                        resultingRecord.iterationList.singleOrNull() shouldBe randomValidationIteration
+                    }
+                }
+            }
+        }
+        val anyValidValidationRecord = Arb.int(min = 1, max = (if (KotestConfig.runTestsExtended) 15 else 5)).flatMap { iterationCount ->
+            anyValidValidationRecord(iterationCount = iterationCount)
+        }
+        "given an empty input" should {
+            "throw an appropriate exception" {
+                checkAll(anyValidValidationRecord.orNull()) { randomExistingRecord ->
+                    shouldThrow<ContractViolationException> {
+                        RecordStandaloneLoanValidationResultsContract(
+                            validationRecord = randomExistingRecord,
+                        ).recordStandaloneLoanValidationResults(
+                            submission = ValidationIteration.getDefaultInstance()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 2
+                        exception.message shouldContain "Request is not set"
+                        exception.message shouldContain "Results are not set"
+                    }
+                }
+            }
+        }
+        "given an input without a valid result ID" should {
+            "throw an appropriate exception" {
+                checkAll(
+                    anyValidValidationRecord.orNull(),
+                    anyValidValidationIteration,
+                    anyInvalidUuid,
+                ) { randomExistingRecord, randomSubmission, randomInvalidId ->
+                    shouldThrow<ContractViolationException> {
+                        RecordStandaloneLoanValidationResultsContract(
+                            validationRecord = randomExistingRecord,
+                        ).recordStandaloneLoanValidationResults(
+                            submission = randomSubmission.toBuilder().also { submissionBuilder ->
+                                submissionBuilder.results = submissionBuilder.results.toBuilder().also { resultsBuilder ->
+                                    resultsBuilder.id = randomInvalidId
+                                }.build()
+                            }.build()
+                        )
+                    }.let { exception ->
+                        exception shouldHaveViolationCount 1
+                        exception.message shouldContain "Results must have valid ID"
+                    }
+                }
+            }
+        }
+        "given an input which does not complete an existing validation request" should {
+            "not throw an exception" {
+                checkAll(
+                    Arb.int(min = 2, max = (if (KotestConfig.runTestsExtended) 15 else 5)).flatMap { iterationCount ->
+                        anyValidValidationRecord(iterationCount = iterationCount)
+                    },
+                ) { randomRecord ->
+                    val (existingIterations, otherIterations) = randomRecord.iterationList.breakOffLast(2)
+                    val (reservedIteration, randomNewIteration) = otherIterations
+                    RecordStandaloneLoanValidationResultsContract(
+                        validationRecord = randomRecord.toBuilder().also { recordBuilder ->
+                            recordBuilder.clearIteration()
+                            recordBuilder.addAllIteration(existingIterations)
+                            recordBuilder.addIteration(
+                                randomNewIteration.toBuilder().also { iterationBuilder ->
+                                    iterationBuilder.clearResults()
+                                }.build()
+                            )
+                        }.build(),
+                    ).recordStandaloneLoanValidationResults(
+                        submission = randomNewIteration
+                    ).let { resultingRecord ->
+                        resultingRecord.iterationList.lastOrNull { iteration ->
+                            iteration.results.id.value == randomNewIteration.results.id.value
+                        } shouldBe randomNewIteration
+                    }
+                }
+            }
+        }
+        "given a valid input" should {
+            "not throw an exception" {
+                checkAll(anyValidValidationRecord, anyValidValidationIteration) { randomRecord, randomSubmission ->
+                    RecordStandaloneLoanValidationResultsContract(
+                        validationRecord = randomRecord,
+                    ).recordStandaloneLoanValidationResults(
+                        submission = randomSubmission
+                    ).let { resultingRecord ->
+                        resultingRecord.iterationList.lastOrNull { iteration ->
+                            iteration.results.id.value == randomSubmission.results.id.value
+                        } shouldBe randomSubmission
+                    }
+                }
+            }
+        }
+    }
+}) {
+    override fun testCaseOrder() = TestCaseOrder.Random
+}

--- a/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContractUnitTest.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/contracts/UpdateFundingContractUnitTest.kt
@@ -522,7 +522,6 @@ class UpdateFundingContractUnitTest : WordSpec({
                             }.build()
                         )
                     }.let { exception ->
-                        exception shouldHaveViolationCount 1
                         exception.message!! shouldContainAtLeastOneOf listOf(
                             "Disbursement amount must not be negative [Iteration${if (invalidAmountIndices.size == 1) "" else "s"} " +
                                 "${invalidAmountIndices.sorted().joinToString()}]",

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/Constructors.kt
@@ -5,6 +5,7 @@ import io.provenance.scope.loan.contracts.AppendLoanStatesContract
 import io.provenance.scope.loan.contracts.RecordLoanContract
 import io.provenance.scope.loan.contracts.RecordLoanValidationRequestContract
 import io.provenance.scope.loan.contracts.RecordLoanValidationResultsContract
+import io.provenance.scope.loan.contracts.RecordStandaloneLoanValidationResultsContract
 import tech.figure.asset.v1beta1.Asset
 import tech.figure.servicing.v1beta1.LoanStateOuterClass.ServicingData
 import tech.figure.servicing.v1beta1.ServicingRightsOuterClass.ServicingRights
@@ -34,7 +35,10 @@ object Constructors {
         get() = RecordLoanValidationResultsContract(
             LoanValidation.getDefaultInstance()
         )
-
+    val standaloneResultsContractWithEmptyExistingRecord: RecordStandaloneLoanValidationResultsContract
+        get() = RecordStandaloneLoanValidationResultsContract(
+            LoanValidation.getDefaultInstance()
+        )
     val requestContractWithEmptyExistingRecord: RecordLoanValidationRequestContract
         get() = RecordLoanValidationRequestContract(
             LoanValidation.getDefaultInstance()

--- a/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
+++ b/contract/src/test/kotlin/io/provenance/scope/loan/test/KotestHelpers.kt
@@ -570,7 +570,7 @@ internal object MetadataAssetModelArbs {
             }.build()
         }.build()
     }
-    fun anyValidValidationIteration(): Arb<ValidationIteration> = Arb.bind(
+    val anyValidValidationIteration: Arb<ValidationIteration> = Arb.bind(
         anyValidValidationRequest,
         anyUuid,
         anyPastNonEpochTimestamp,
@@ -669,7 +669,7 @@ internal object MetadataAssetModelArbs {
         slippage: Int = 30,
     ): Arb<LoanValidation> = Arb.bind(
         Arb.list(
-            anyValidValidationIteration(),
+            anyValidValidationIteration,
             range = iterationCount..iterationCount
         ),
         anyUuidSet(size = iterationCount, slippage = slippage),


### PR DESCRIPTION
## Context
The current `RecordLoanValidationResultsContract` is designed for interactions between two parties where one is submitting requests for validation and the other is submitting their fulfillment of those requests. However, for cases where a single party wishes to submit validation results, the contract is not suitable. For this usecase, it would be ideal to define a new contract where the submission is not required to match against an existing request in the record, and simply adds another validation iteration which contains both a request and results.
## Changes
- Define a new contract for uploading a combined validation request and results
- Add missing test cases to enforce the distinction between the now two different contracts for uploading validation results
- Remove requirement for validation requests to specify block height
- Fix failing funding contract unit test edge case