### PR TITLE
Relax validation for loan funding data

### DIFF
--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
@@ -12,7 +12,7 @@ internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = {
             requireThat(
                 (fundingStatus.status in listOf("UNFUNDED", "INITIATED", "FUNDED", "CANCELLED"))
                     orError "Funding status must be valid",
-                fundingStatus.effectiveTime.isValidFundingTime()
+                (fundingStatus.effectiveTime.isNotSet() || fundingStatus.effectiveTime.isValidFundingTime())
                     orError "Funding status must have valid effective time",
             )
             when (fundingStatus.status) {

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
@@ -57,7 +57,7 @@ internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = {
                             disbursementStatus.effectiveTime.isValidFundingTime() orError "Disbursement must have valid effective time",
                         )
                         when (disbursementStatus.status) {
-                            in listOf("COMPLETED", "FUNDED") -> {
+                            in listOf("COMPLETE", "COMPLETED", "FUNDED") -> {
                                 requireThat(
                                     setDisbursement.started.isValidFundingTime()   orError "Completed disbursement's start time must be valid",
                                     setDisbursement.completed.isValidFundingTime() orError "Completed disbursement's end time must be valid",

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
@@ -53,14 +53,17 @@ internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = {
                     )
                     setDisbursement.status.takeIf { it.isSet() }?.also { disbursementStatus ->
                         requireThat(
-                            disbursementStatus.status.isNotBlank()                orError "Disbursement status must not be empty",
-                            disbursementStatus.effectiveTime.isValidFundingTime() orError "Disbursement must have valid effective time",
+                            disbursementStatus.status.isNotBlank() orError "Disbursement status must not be empty",
+                            (disbursementStatus.effectiveTime.isNotSet() || disbursementStatus.effectiveTime.isValidFundingTime())
+                                orError "Disbursement status must have valid effective time",
                         )
                         when (disbursementStatus.status) {
                             in listOf("COMPLETE", "COMPLETED", "FUNDED") -> {
                                 requireThat(
-                                    setDisbursement.started.isValidFundingTime()   orError "Completed disbursement's start time must be valid",
-                                    setDisbursement.completed.isValidFundingTime() orError "Completed disbursement's end time must be valid",
+                                    (setDisbursement.started.isNotSet() || setDisbursement.started.isValidFundingTime())
+                                        orError "Completed disbursement's start time must be valid",
+                                    (setDisbursement.completed.isNotSet() || setDisbursement.completed.isValidFundingTime())
+                                        orError "Completed disbursement's end time must be valid",
                                 )
                                 if (setDisbursement.started.isValidFundingTime() && setDisbursement.completed.isValidFundingTime()) {
                                     requireThat(
@@ -71,12 +74,14 @@ internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = {
                             }
                             "CANCELLED" -> {
                                 requireThat(
-                                    setDisbursement.completed.isValidFundingTime() orError "Cancelled disbursement's end time must be valid",
+                                    (setDisbursement.completed.isNotSet() || setDisbursement.completed.isValidFundingTime())
+                                        orError "Cancelled disbursement's end time must be valid",
                                 )
                             }
                             !in listOf("UNFUNDED", "UNKNOWN") -> {
                                 requireThat(
-                                    setDisbursement.started.isValidFundingTime() orError "Disbursement start time must be valid",
+                                    (setDisbursement.started.isNotSet() || setDisbursement.started.isValidFundingTime())
+                                        orError "Disbursement start time must be valid",
                                 )
                             }
                         }

--- a/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
+++ b/contract/src/main/kotlin/io/provenance/scope/loan/utility/FundingDataValidation.kt
@@ -29,12 +29,12 @@ internal val fundingValidation: ContractEnforcementContext.(Funding) -> Unit = {
                 }
                 "CANCELLED" -> {
                     requireThat(
-                        funding.completed.isValidFundingTime() orError "Cancelled funding's end time must be valid",
+                        (funding.completed.isNotSet() || funding.completed.isValidFundingTime()) orError "Cancelled funding's end time must be valid",
                     )
                 }
                 !in listOf("UNFUNDED", "UNKNOWN") -> {
                     requireThat(
-                        funding.started.isValidFundingTime() orError "Funding start time must be valid",
+                        (funding.started.isNotSet() || funding.started.isValidFundingTime()) orError "Funding start time must be valid",
                     )
                 }
             }


### PR DESCRIPTION
## Context
Relaxing multiple data validations made for specific fields in the funding field, particularly around effective times, to only check for a valid (AKA non-future) timestamp if the field itself is set to a non-default value. This supports cases where
- times are not set on individual disbursement entries, in favor of setting the top-level start & end times
- when funding is cancelled, unstarted, or incomplete
## Changes
- Update funding contract's input validation to only validate specific time fields if they are set
- Treat a funding status string of "COMPLETE" the same as "COMPLETED" or "FUNDED"